### PR TITLE
Fix mobile sidebar overlapping header buttons

### DIFF
--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -250,12 +250,13 @@ function Navbar() {
         <AnimatePresence>
           {isMobileMenuOpen && (
             <motion.div
-              initial={{ opacity: 0, height: 0 }}
-              animate={{ opacity: 1, height: "auto" }}
-              exit={{ opacity: 0, height: 0 }}
-              transition={{ duration: 0.3 }}
-              className="md:hidden overflow-hidden"
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.3 }}
+                className="md:hidden fixed top-24 left-0 w-full z-40 bg-[#161920] overflow-hidden"
             >
+
               <div className="pt-2 pb-4 space-y-2">
                 {/* Navigation Links */}
                 {/* {navItems.map((item) => (


### PR DESCRIPTION
### Problem
On mobile screens, the fixed navbar caused the mobile menu to expand inside it,
leading to overlap with header buttons.

### Solution
Updated the mobile menu to render as a fixed overlay positioned below the navbar
height, preventing overlap while keeping desktop behavior unchanged.

### Notes
Local runtime requires a WalletConnect projectId, so the fix was validated via
responsive layout inspection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile menu animation with smoother vertical transitions.
  * Updated mobile menu to display as a fixed overlay with improved visual hierarchy.
  * Enhanced mobile menu styling with dark background for better contrast against page content.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->