### PR TITLE
feat: display dynamic currency symbol based on connected network

### DIFF
--- a/frontend/src/components/CustomBalance.jsx
+++ b/frontend/src/components/CustomBalance.jsx
@@ -1,0 +1,23 @@
+import { useAccount, useBalance } from 'wagmi';
+
+export const CustomBalance = () => {
+  const { address, isConnected, chain } = useAccount();
+  const { data: balance, isLoading } = useBalance({ address });
+
+  if (!isConnected || !balance) return null;
+
+  
+  const symbol = chain?.nativeCurrency?.symbol || balance.symbol || 'ETH';
+  const formatted = parseFloat(balance.formatted).toFixed(4);
+
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 bg-gray-800/50 rounded-lg border border-gray-700/50">
+      <span className="text-sm font-semibold text-white">
+        {isLoading ? '...' : formatted}
+      </span>
+      <span className="text-xs font-medium text-green-400">
+        {symbol}
+      </span>
+    </div>
+  );
+};

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -1,5 +1,6 @@
 // Updated Navbar.js
 import { ConnectButton } from "@rainbow-me/rainbowkit";
+import { CustomBalance } from './CustomBalance';
 import React, { useEffect, useState } from "react";
 import { Link, useNavigate, useLocation } from "react-router-dom";
 import { useAccount } from "wagmi";
@@ -206,13 +207,11 @@ function Navbar() {
               whileTap={{ scale: 0.95 }}
               className="ml-4"
             >
+             <CustomBalance />
               <ConnectButton
                 accountStatus="address"
-                chainStatus="none"
-                showBalance={{
-                  smallScreen: false,
-                  largeScreen: true,
-                }}
+                chainStatus="icon"
+                showBalance={false}
                 label="Connect Wallet"
               />
             </motion.div>


### PR DESCRIPTION
This PR fixes the hardcoded "ETH" currency display in the wallet balance. The balance now dynamically shows the correct native currency symbol based on the connected blockchain network.

Problem
Currently, the wallet balance always displays "ETH" regardless of which network the user is connected to:
- Connected to Polygon → Shows "ETH" ❌ (should show "POL")
- Connected to BSC → Shows "ETH" ❌ (should show "BNB")


Before:
<img width="1920" height="1080" alt="Screenshot (147)" src="https://github.com/user-attachments/assets/ce065d2d-9819-404e-b2d7-2a336f257a1b" />

Solution
Created a `CustomBalance` component that:
- Uses `useAccount()` hook to detect the connected chain
- Uses `useBalance()` hook to fetch wallet balance
- Dynamically displays `chain.nativeCurrency.symbol` instead of hardcoded "ETH"
- Works with any EVM-compatible chain without additional configuration

After:
<img width="1920" height="1080" alt="Screenshot (145)" src="https://github.com/user-attachments/assets/fe67138c-cf2d-4165-8bf8-1a6298094cef" />
<img width="1920" height="1080" alt="Screenshot (144)" src="https://github.com/user-attachments/assets/ccdacdc0-1113-43c9-a520-a8e9c55ba716" />

🔧 Changes Made
- ✅ Created `frontend/src/components/CustomBalance.jsx`
- ✅ Updated `frontend/src/components/Navbar.jsx` to use `CustomBalance`
- ✅ Removed hardcoded "ETH" references
- ✅ Set `showBalance={false}` on RainbowKit's ConnectButton

🧪 Testing
Tested on the following networks:
- [x] Ethereum Mainnet - Shows "ETH" ✅
- [x] Polygon - Shows "POL" ✅
- [x] Binance Smart Chain - Shows "BNB" ✅
- [x] Arbitrum - Shows "ETH" ✅



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Custom balance display added to the navbar showing connected wallet balance and currency symbol
  * Balance updates dynamically with four decimal precision; displays loading indicator when data is unavailable

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->