### PR TITLE
fixed-togglebar-color-issue

### DIFF
--- a/frontend/src/components/TokenPicker.jsx
+++ b/frontend/src/components/TokenPicker.jsx
@@ -62,8 +62,8 @@ export const ToggleSwitch = ({ enabled, onChange, leftLabel, rightLabel }) => (
       className={cn(
         "relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none ",
         enabled
-          ? "bg-green-500 focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
-          : "bg-gray-300 focus:ring-2 focus:ring-gray-400 focus:ring-offset-2"
+          ? "bg-green-600 focus:ring-2 focus:ring-green-600 focus:ring-offset-2"
+          : "bg-gray-600 focus:ring-2 focus:ring-gray-600 focus:ring-offset-2"
       )}
     >
       <span


### PR DESCRIPTION
# Fix Toggle Switch Color Scheme

Fixed counterintuitive toggle colors in `TokenPicker` component.

**Before:** ON = Blue, OFF = Green  
**After:** ON = Green, OFF = Gray

This aligns with standard UX patterns where green indicates active state, making the toggle state instantly recognizable.

**Files Changed:** `frontend/src/components/TokenPicker.jsx`

## Here You Go! how it looks now !
<img width="1416" height="492" alt="Screenshot From 2025-12-30 12-37-31" src="https://github.com/user-attachments/assets/a3d0364f-7e98-4075-a2f9-296e7a9b6080" />
<img width="1416" height="492" alt="Screenshot From 2025-12-30 12-37-37" src="https://github.com/user-attachments/assets/70dc25ac-7924-4d75-92a4-ff1adb2e0298" />
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated toggle switch styling: enabled state now displays in green (previously blue), disabled state displays in gray with updated focus styling (previously green).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->