### PR TITLE
configure chain selector to show 5 networks

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -7,7 +7,7 @@ import {
 import { WagmiProvider } from "wagmi";
 import { QueryClientProvider, QueryClient } from "@tanstack/react-query";
 import * as chains from "wagmi/chains";
-
+import { mainnet, classic, base, bsc, polygon } from 'wagmi/chains';
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
 import Landing from "./page/Landing";
 import Applayout from "./page/Applayout";
@@ -22,7 +22,7 @@ import CreateInvoice from "./page/CreateInvoice";
 import SentInvoice from "./page/SentInvoice";
 import ReceivedInvoice from "./page/ReceivedInvoice";
 
-const AllChains = [...Object.values(chains), citreaTestnet];
+const AllChains = [ mainnet, classic, base, bsc, polygon];
 
 export const config = getDefaultConfig({
   appName: "Chainvoice",

--- a/frontend/src/components/Navbar.jsx
+++ b/frontend/src/components/Navbar.jsx
@@ -208,7 +208,7 @@ function Navbar() {
             >
               <ConnectButton
                 accountStatus="address"
-                chainStatus="none"
+                chainStatus="full"
                 showBalance={{
                   smallScreen: false,
                   largeScreen: true,
@@ -298,8 +298,8 @@ function Navbar() {
                 <div className="px-4 py-2">
                   <ConnectButton
                     accountStatus="full"
-                    chainStatus="none"
-                    showBalance={false}
+                    chainStatus="full"
+                    showBalance={true}
                   />
                 </div>
               </div>


### PR DESCRIPTION
configured the chain selector to show 5 networks and also configured the connectButton to show chain selector in navbar near wallet balance.

previously (without configuration) ->
<img width="1902" height="221" alt="image" src="https://github.com/user-attachments/assets/372ad47a-6490-4ef5-b7bc-6a8c383d3fad" />


now (with configuration) -> 
<img width="1917" height="222" alt="image" src="https://github.com/user-attachments/assets/7877c9b8-d4d7-44bf-bf8d-5343cb727fe4" />


available networks to select in chain selector -> 
<img width="691" height="533" alt="image" src="https://github.com/user-attachments/assets/5198c1c9-c7ae-46a0-aeca-e435cefb4285" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Improvements**
  * Enhanced wallet connection interface to display chain status by default on both desktop and mobile views.
  * Mobile wallet display now includes account balance visibility.

* **Updates**
  * Blockchain network support updated to explicitly support Ethereum mainnet, Ethereum Classic, Base, BSC, and Polygon.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->