### PR TITLE
Fix Query Parameter Handling in 404 Redirect Script

### DIFF
--- a/frontend/public/404.html
+++ b/frontend/public/404.html
@@ -20,7 +20,7 @@
             l.protocol + '//' + l.hostname + (l.port ? ':' + l.port : '') +
             l.pathname.split('/').slice(0, 1 + pathSegmentsToKeep).join('/') + '/?/' +
             l.pathname.slice(1).split('/').slice(pathSegmentsToKeep).join('/').replace(/&/g, '~and~') +
-            (l.search ? '&q=' + l.search.slice(1).replace(/&/g, '~and~') : '') +
+            (l.search ? '&' + l.search.slice(1).replace(/&/g, '~and~') : '') +
             l.hash
         );
     </script>


### PR DESCRIPTION
Fixes #58 

Description:
This pull request resolves the issue where query parameters in shared links were incorrectly wrapped in a q= container during redirection from the 404.html. This caused the application to fail in parsing query parameters like clientAddress  and tokenAddress, preventing form fields from being pre-filled for users accessing shared links.

Changes Made:
Updated 404.html Modified the script to preserve query parameters in their original format without wrapping them in q=.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved how query parameters are preserved when redirecting from error pages, ensuring search parameters are correctly maintained in the redirect URL.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->