### PR TITLE
chore(footer): replace static year with dynamic year

### DIFF
--- a/frontend/src/page/Landing.jsx
+++ b/frontend/src/page/Landing.jsx
@@ -5,6 +5,7 @@ import { SiEthereum } from "react-icons/si";
 import TokenCarousel from "@/components/TokenCrousel";
 
 function Landing() {
+  const year = new Date().getFullYear();
   return (
     <div className="bg-[#0F1015] text-white min-h-screen">
       {/* Hero Section */}
@@ -277,7 +278,7 @@ function Landing() {
             </div>
 
             <p className="text-gray-400 text-lg text-center">
-              © 2025 Stability Nexus. All rights reserved.
+              © {year} Stability Nexus. All rights reserved.
             </p>
 
             <div className="flex items-center gap-9">


### PR DESCRIPTION
This pull request replaces the static copyright year in the footer with a dynamic year that updates automatically based on the current date. This ensures the footer always remains accurate without requiring manual updates every year.

fixes: #77 

**After**
<img width="1814" height="341" alt="Screenshot 2026-01-21 203716" src="https://github.com/user-attachments/assets/6a4b3630-c8fd-4757-88d7-248439ec3972" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The copyright year on the landing page now automatically updates each year, eliminating the need for manual updates.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->