### PR TITLE
Added the onlyOwner modifier to the function signature.

### DIFF
--- a/contracts/src/Chainvoice.sol
+++ b/contracts/src/Chainvoice.sol
@@ -382,7 +382,7 @@ contract Chainvoice {
         treasuryAddress = newTreasury;
     }
 
-    function withdrawFees() external {
+    function withdrawFees() external onlyOwner {
         require(treasuryAddress != address(0), "Treasury not set");
         require(accumulatedFees > 0, "No fees available");
 


### PR DESCRIPTION
### Changes Made:

- Added the onlyOwner modifier to the function signature.

- This ensures that only the contract owner (the address that deployed the contract) can trigger the withdrawal of accumulated fees to the treasury address.

@kumawatkaran523 Please checkout this Patch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted fee withdrawal to the contract owner, closing an access gap that previously allowed unrestricted calls. This strengthens fund protection and aligns behavior with expected permissions. Users and integrators do not need to change workflows; only the designated owner can initiate withdrawals. All other contract operations remain unchanged.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->