### PR TITLE
fix(pdf): render dynamic native token and network fee symbol

### DIFF
--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -363,6 +363,14 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
     tokenSymbol,
     tokenDecimals,
   } = paymentContext;
+  if (
+    !isNativePayment &&
+    (!invoice.paymentToken?.symbol || invoice.paymentToken?.decimals == null)
+  ) {
+    throw new Error(
+      `Cannot generate PDF: missing ERC-20 token metadata for ${invoice.paymentToken?.address || "unknown token"} on chain ${chainId}.`
+    );
+  }
   pdf.text(`${tokenName} (${tokenSymbol})`, 25, yPos + 14);
 
   pdf.setFontSize(8);

--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -347,6 +347,14 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
   const chainId = invoice.paymentToken?.chainId || invoice.chainId;
   const network = getWagmiChainInfo(chainId);
   const chainName = network?.name || getWagmiChainName(chainId) || "Unknown network";
+  let paymentContext;
+  try {
+    paymentContext = resolveInvoicePaymentContext(invoice, network);
+  } catch (err) {
+    throw new Error(
+      `Cannot generate PDF: unsupported chain (ID: ${chainId}). ${err.message}`
+    );
+  }
   const {
     nativeSymbol,
     nativeDecimals,
@@ -354,7 +362,7 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
     tokenName,
     tokenSymbol,
     tokenDecimals,
-  } = resolveInvoicePaymentContext(invoice, network);
+  } = paymentContext;
   pdf.text(`${tokenName} (${tokenSymbol})`, 25, yPos + 14);
 
   pdf.setFontSize(8);

--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -558,6 +558,7 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
     fee,
     networkFee,
     nativeSymbol,
+    nativeDecimals,
   });
 
   pdf.setFontSize(11);

--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -359,7 +359,7 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
 
   pdf.setFontSize(8);
   pdf.setTextColor(...mediumGray);
-  if (invoice.paymentToken?.address) {
+  if (!isNativePayment && invoice.paymentToken?.address) {
     const contractAddr = invoice.paymentToken.address;
     const shortAddr = `${contractAddr.substring(0, 10)}......${contractAddr.substring(contractAddr.length - 8)}`;
     pdf.text(shortAddr, 25, yPos + 19);

--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -1,6 +1,10 @@
 import jsPDF from "jspdf";
-import { ethers } from "ethers";
 import { getWagmiChainName, getWagmiChainInfo } from "./wagmiChainHelpers";
+import {
+  buildInvoiceTotalText,
+  formatNetworkFeeValue,
+  resolveInvoicePaymentContext,
+} from "./invoicePaymentSymbols";
 
 /**
  * Load logo image with multiple fallback methods
@@ -340,8 +344,17 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
 
   pdf.setFontSize(10);
   pdf.setFont("helvetica", "normal");
-  const tokenName = invoice.paymentToken?.name || "Ether";
-  const tokenSymbol = invoice.paymentToken?.symbol || "ETH";
+  const chainId = invoice.paymentToken?.chainId || invoice.chainId;
+  const network = getWagmiChainInfo(chainId);
+  const chainName = network?.name || getWagmiChainName(chainId) || "Unknown network";
+  const {
+    nativeSymbol,
+    nativeDecimals,
+    isNativePayment,
+    tokenName,
+    tokenSymbol,
+    tokenDecimals,
+  } = resolveInvoicePaymentContext(invoice, network);
   pdf.text(`${tokenName} (${tokenSymbol})`, 25, yPos + 14);
 
   pdf.setFontSize(8);
@@ -350,11 +363,8 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
     const contractAddr = invoice.paymentToken.address;
     const shortAddr = `${contractAddr.substring(0, 10)}......${contractAddr.substring(contractAddr.length - 8)}`;
     pdf.text(shortAddr, 25, yPos + 19);
-    const chainId = invoice.paymentToken?.chainId || invoice.chainId;
-    const network = getWagmiChainInfo(chainId);
-    const chainName = network?.name || getWagmiChainName(chainId) || "Unknown network";
     pdf.text(
-      `Decimals: ${invoice.paymentToken.decimals || 18} | Chain: ${chainName}`,
+      `Decimals: ${tokenDecimals} | Chain: ${chainName}`,
       120,
       yPos + 14
     );
@@ -523,8 +533,8 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
   pdf.setFont("helvetica", "normal");
   pdf.text("Network Fee:", 25, yPos + 13);
   pdf.setFont("helvetica", "bold");
-  const networkFee = ethers.formatUnits(fee);
-  pdf.text(`${networkFee} ETH`, 185, yPos + 13, { align: "right" });
+  const networkFee = formatNetworkFeeValue(fee, nativeDecimals);
+  pdf.text(`${networkFee} ${nativeSymbol}`, 185, yPos + 13, { align: "right" });
 
   pdf.setDrawColor(...mediumGray);
   pdf.setLineWidth(0.5);
@@ -540,27 +550,15 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
   pdf.setTextColor(...darkGray);
   pdf.text("TOTAL AMOUNT:", 25, yPos + 25);
 
-
-  let totalText;
-  if (tokenSymbol === "ETH") {
-    // Use ethers.BigNumber for precise addition in wei
-    let amountDueWei, networkFeeWei;
-    try {
-      amountDueWei = ethers.parseUnits(invoice.amountDue || "0", 18);
-    } catch {
-      amountDueWei = 0n;
-    }
-    try {
-      networkFeeWei = ethers.parseUnits(networkFee || "0", 18);
-    } catch {
-      networkFeeWei = 0n;
-    }
-    const totalWei = amountDueWei + networkFeeWei;
-    const totalEth = ethers.formatUnits(totalWei, 18);
-    totalText = `${Number(totalEth).toFixed(6)} ETH`;
-  } else {
-    totalText = `${invoice.amountDue} ${tokenSymbol} + ${networkFee} ETH`;
-  }
+  const totalText = buildInvoiceTotalText({
+    isNativePayment,
+    amountDue: invoice.amountDue,
+    tokenSymbol,
+    tokenDecimals,
+    fee,
+    networkFee,
+    nativeSymbol,
+  });
 
   pdf.setFontSize(11);
   pdf.text(totalText, 185, yPos + 25, { align: "right" });

--- a/frontend/src/utils/generateInvoicePDF.js
+++ b/frontend/src/utils/generateInvoicePDF.js
@@ -570,7 +570,6 @@ export const generateInvoicePDF = async (invoice, fee = 0) => {
     isNativePayment,
     amountDue: invoice.amountDue,
     tokenSymbol,
-    tokenDecimals,
     fee,
     networkFee,
     nativeSymbol,

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -6,14 +6,14 @@ export const resolveInvoicePaymentContext = (invoice, network) => {
   
   // Use Wagmi network info to get correct native token symbol, name, and decimals
   // wagmi chain object typically has nativeCurrency: { name: 'Matic', symbol: 'MATIC', decimals: 18 }
-  const nativeSymbol = network?.nativeCurrency?.symbol || "ETH";
-  const nativeDecimals = network?.nativeCurrency?.decimals || 18;
-  const nativeName = network?.nativeCurrency?.name || "Ether";
+  const nativeSymbol = network?.nativeCurrency?.symbol ?? "ETH";
+  const nativeDecimals = network?.nativeCurrency?.decimals ?? 18;
+  const nativeName = network?.nativeCurrency?.name ?? "Ether";
 
   // Use provided token info, or default to the native chain info
-  const tokenName = invoice.paymentToken?.name || nativeName;
-  const tokenSymbol = invoice.paymentToken?.symbol || nativeSymbol;
-  const tokenDecimals = invoice.paymentToken?.decimals || nativeDecimals;
+  const tokenName = isNativePayment ? nativeName : (invoice.paymentToken?.name ?? nativeName);
+  const tokenSymbol = isNativePayment ? nativeSymbol : (invoice.paymentToken?.symbol ?? nativeSymbol);
+  const tokenDecimals = isNativePayment ? nativeDecimals : (invoice.paymentToken?.decimals ?? nativeDecimals);
 
   return {
     nativeSymbol,
@@ -41,13 +41,14 @@ export const buildInvoiceTotalText = ({
   fee,
   networkFee,
   nativeSymbol,
+  nativeDecimals,
 }) => {
   // If payment is in native currency, sum up the amount due and network fee safely using BigInt
   if (isNativePayment) {
     let amountDueWei, networkFeeWei;
     
     try {
-      amountDueWei = ethers.parseUnits(amountDue || "0", tokenDecimals || 18);
+      amountDueWei = ethers.parseUnits(amountDue || "0", nativeDecimals ?? 18);
     } catch {
       amountDueWei = 0n;
     }
@@ -59,10 +60,12 @@ export const buildInvoiceTotalText = ({
     }
 
     const totalWei = amountDueWei + networkFeeWei;
-    const totalAmount = ethers.formatUnits(totalWei, tokenDecimals || 18);
+    const totalAmount = ethers.formatUnits(totalWei, nativeDecimals ?? 18);
     
-    // Using .toFixed(6) to prevent extremely long decimals
-    return `${Number(totalAmount).toFixed(6)} ${nativeSymbol}`;
+    // Truncate to 6 decimal places without Number conversion
+    const [intPart, decPart = ""] = totalAmount.split(".");
+    const truncatedDec = decPart.slice(0, 6).padEnd(6, "0");
+    return `${intPart}.${truncatedDec} ${nativeSymbol}`;
   }
 
   // If ERC20 payment, show token amount + network fee in native token

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -1,14 +1,20 @@
 import { ethers } from "ethers";
 
 export const resolveInvoicePaymentContext = (invoice, network) => {
-  // If no payment token is set, it's a native currency payment
-  const isNativePayment = !invoice.paymentToken || !invoice.paymentToken.address;
+  const tokenAddress = invoice.paymentToken?.address;
+  const isNativePayment = !tokenAddress || tokenAddress === ethers.ZeroAddress;
+
+  if (!network?.nativeCurrency) {
+    throw new Error("Missing native currency metadata for invoice payment context");
+  }
   
   // Use Wagmi network info to get correct native token symbol, name, and decimals
   // wagmi chain object typically has nativeCurrency: { name: 'Matic', symbol: 'MATIC', decimals: 18 }
-  const nativeSymbol = network?.nativeCurrency?.symbol ?? "ETH";
-  const nativeDecimals = network?.nativeCurrency?.decimals ?? 18;
-  const nativeName = network?.nativeCurrency?.name ?? "Ether";
+  const {
+    symbol: nativeSymbol,
+    decimals: nativeDecimals,
+    name: nativeName,
+  } = network.nativeCurrency;
 
   // Use provided token info, or default to the native chain info
   const tokenName = isNativePayment ? nativeName : (invoice.paymentToken?.name ?? nativeName);

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -1,0 +1,70 @@
+import { ethers } from "ethers";
+
+export const resolveInvoicePaymentContext = (invoice, network) => {
+  // If no payment token is set, it's a native currency payment
+  const isNativePayment = !invoice.paymentToken || !invoice.paymentToken.address;
+  
+  // Use Wagmi network info to get correct native token symbol, name, and decimals
+  // wagmi chain object typically has nativeCurrency: { name: 'Matic', symbol: 'MATIC', decimals: 18 }
+  const nativeSymbol = network?.nativeCurrency?.symbol || "ETH";
+  const nativeDecimals = network?.nativeCurrency?.decimals || 18;
+  const nativeName = network?.nativeCurrency?.name || "Ether";
+
+  // Use provided token info, or default to the native chain info
+  const tokenName = invoice.paymentToken?.name || nativeName;
+  const tokenSymbol = invoice.paymentToken?.symbol || nativeSymbol;
+  const tokenDecimals = invoice.paymentToken?.decimals || nativeDecimals;
+
+  return {
+    nativeSymbol,
+    nativeDecimals,
+    isNativePayment,
+    tokenName,
+    tokenSymbol,
+    tokenDecimals,
+  };
+};
+
+export const formatNetworkFeeValue = (fee, nativeDecimals) => {
+  try {
+    return ethers.formatUnits(fee || "0", nativeDecimals || 18);
+  } catch {
+    return "0.0";
+  }
+};
+
+export const buildInvoiceTotalText = ({
+  isNativePayment,
+  amountDue,
+  tokenSymbol,
+  tokenDecimals,
+  fee,
+  networkFee,
+  nativeSymbol,
+}) => {
+  // If payment is in native currency, sum up the amount due and network fee safely using BigInt
+  if (isNativePayment) {
+    let amountDueWei, networkFeeWei;
+    
+    try {
+      amountDueWei = ethers.parseUnits(amountDue || "0", tokenDecimals || 18);
+    } catch {
+      amountDueWei = 0n;
+    }
+
+    try {
+      networkFeeWei = BigInt(fee || "0");
+    } catch {
+      networkFeeWei = 0n;
+    }
+
+    const totalWei = amountDueWei + networkFeeWei;
+    const totalAmount = ethers.formatUnits(totalWei, tokenDecimals || 18);
+    
+    // Using .toFixed(6) to prevent extremely long decimals
+    return `${Number(totalAmount).toFixed(6)} ${nativeSymbol}`;
+  }
+
+  // If ERC20 payment, show token amount + network fee in native token
+  return `${amountDue || "0"} ${tokenSymbol} + ${networkFee} ${nativeSymbol}`;
+};

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -33,7 +33,7 @@ export const resolveInvoicePaymentContext = (invoice, network) => {
 
 export const formatNetworkFeeValue = (fee, nativeDecimals) => {
   try {
-    return ethers.formatUnits(fee || "0", nativeDecimals || 18);
+    return ethers.formatUnits(fee || "0", nativeDecimals ?? 18);
   } catch {
     return "0.0";
   }

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -67,11 +67,8 @@ export const buildInvoiceTotalText = ({
 
     const totalWei = amountDueWei + networkFeeWei;
     const totalAmount = ethers.formatUnits(totalWei, nativeDecimals ?? 18);
-    
-    // Truncate to 6 decimal places without Number conversion
-    const [intPart, decPart = ""] = totalAmount.split(".");
-    const truncatedDec = decPart.slice(0, 6).padEnd(6, "0");
-    return `${intPart}.${truncatedDec} ${nativeSymbol}`;
+
+    return `${totalAmount} ${nativeSymbol}`;
   }
 
   // If ERC20 payment, show token amount + network fee in native token

--- a/frontend/src/utils/invoicePaymentSymbols.js
+++ b/frontend/src/utils/invoicePaymentSymbols.js
@@ -43,7 +43,6 @@ export const buildInvoiceTotalText = ({
   isNativePayment,
   amountDue,
   tokenSymbol,
-  tokenDecimals,
   fee,
   networkFee,
   nativeSymbol,


### PR DESCRIPTION
### Addressed Issues:

Fixes #150 


### Screenshots/Recordings:

**Before:**
- The PDF generator hardcoded "ETH" for native token representation and network fee labels regardless of the active chain (e.g., it showed ETH on MATIC/BSC chains).

| BSC Native | ERC20 AAVE (Polygon) |
| --- | --- |
| <img alt="-bsc-native" src="https://github.com/user-attachments/assets/b1bae97c-e97a-4e0d-8a6f-1946f485964c" /> | <img alt="erc20-aave" src="https://github.com/user-attachments/assets/24908400-20fe-4151-b4f5-ebead7fe3155" /> |
| **Ethereum Native** | **Polygon Native** |
| <img alt="ethereum-native" src="https://github.com/user-attachments/assets/50fd4f32-223b-4b8d-aa02-d4f2a3792ad9" /> | <img alt="polygon-native" src="https://github.com/user-attachments/assets/4ed47e5d-8705-4357-bfe7-ae1b9ee090b3" /> |


**After:**
- Invoice PDF dynamically renders the correct native token symbol based on the active Wagmi network context.
- Handles both native coin paths (e.g., MATIC) and ERC-20 payment paths (e.g., utilizing the AAVE/BONK tokens from the dropdown menu) while still accurately calculating and displaying the network fee in the native currency.

| BSC Native | ERC20 AAVE (Polygon) |
| --- | --- |
| <img alt="bsc-native" src="https://github.com/user-attachments/assets/6d3c5b7d-841c-4d35-b4f5-82d616a1328e" /> | <img alt="erc20-aave" src="https://github.com/user-attachments/assets/15e58f3c-f5eb-4f38-b79f-ea669d1abcdd" /> |
| **Ethereum Native** | **Polygon Native** |
| <img alt="ethereum-native" src="https://github.com/user-attachments/assets/d552f70c-dc6b-427c-801a-f83dde3d1a83" /> | <img alt="polygon-native" src="https://github.com/user-attachments/assets/b7c88411-1cc0-4861-9eda-46227d7ddb30" /> |

<br />



### Additional Notes:

#### Local Testing Snippet Used for Screenshots:
*(Ran this script in the browser console on localhost to generate the attached PDF variants)*

<details>
<summary>Click to view Browser Console PDF Test Script</summary>

```javascript
const mod = await import("/src/utils/generateInvoicePDF.js");

const generateTestInvoice = async (filename, chainId, paymentToken, amountDue, feeWei) => {
  const invoice = {
    id: Math.floor(Math.random() * 10000),
    isCancelled: false,
    isPaid: false,
    amountDue,
    issueDate: new Date().toISOString(),
    dueDate: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString(),
    chainId,
    paymentToken,
    user: { fname: "Alice", address: "0x1111111111111111111111111111111111111111" },
    client: { fname: "Bob", address: "0x2222222222222222222222222222222222222222" },
    items: [{ description: "Development", qty: "1", unitPrice: amountDue, discount: "0", tax: "0", amount: amountDue }]
  };
  const pdf = await mod.generateInvoicePDF(invoice, feeWei);
  pdf.save(filename);
};

// Create a small delay function
const sleep = (ms) => new Promise(r => setTimeout(r, ms));

console.log("Generating Case 1...");
await generateTestInvoice("1-polygon-native.pdf", 137, null, "1.25", "21000000000000");
await sleep(1500); // Wait 1.5 seconds

console.log("Generating Case 2...");
await generateTestInvoice("2-bsc-native.pdf", 56, null, "5.50", "150000000000000");
await sleep(1500);

console.log("Generating Case 3...");
await generateTestInvoice("3-erc20-aave.pdf", 137, { name: "Aave", symbol: "AAVE", address: "0xd6df93...", decimals: 18, chainId: 137 }, "10.0", "21000000000000");
await sleep(1500);

console.log("Generating Case 4...");
await generateTestInvoice("4-ethereum-native.pdf", 1, null, "0.5", "5000000000000000");

console.log("All 4 PDFs should be downloaded now!");
```
</details>




- Extracted network formatting and Wei conversion logic natively into a new [invoicePaymentSymbols.js](cci:7://file:///d:/open%20source/Chainvoice/frontend/src/utils/invoicePaymentSymbols.js:0:0-0:0) utility helper to decouple it from PDF generation.
- Standardized the Wei addition mechanisms utilizing `BigInt` for natively accurate precision without deep decimals.
- Cleaned up obsolete `ethers` import references inside [generateInvoicePDF.js](cci:7://file:///d:/open%20source/Chainvoice/frontend/src/utils/generateInvoicePDF.js:0:0-0:0) natively.


### AI Usage Disclosure:

We encourage contributors to use AI tools responsibly when creating Pull Requests. While AI can be a valuable aid, it is essential to ensure that your contributions meet the task requirements, build successfully, include relevant tests, and pass all linters. Submissions that do not meet these standards may be closed without warning to maintain the quality and integrity of the project. Please take the time to understand the changes you are proposing and their impact. AI slop is strongly discouraged and may lead to banning and blocking. Do not spam our repos with AI slop.

Check one of the checkboxes below:

- [x] This PR does not contain AI-generated code at all.
- [ ] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: None


## Checklist
<!-- Mark items with [x] to indicate completion -->
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Invoice PDF displays the correct native currency symbol and uses resolved native decimals for network fees and totals.
  * Payment section toggles properly between token details (contract, decimals, chain) and "Native Currency".
  * Token payments without ERC‑20 metadata now produce a clear validation error; network fee formatting is more robust.

* **Refactor**
  * Centralized payment-context resolution and unified total construction for consistent native vs. token displays.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->