### PR TITLE
chore: sync ChainvoiceABI with deployed hash-based contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,18 +145,32 @@ npm run dev
 ### Frontend Configuration (`frontend/.env`)  
 ```.env
 #Ethereum Sepolia (11155111)
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
-#Ethereum Classic (61)
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
-#Polygon Mainnet (137)
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
+#Ethereum Classic (61) — blank until redeployed, see note below
+VITE_CONTRACT_ADDRESS_61=
+#Polygon Mainnet (137) — blank until redeployed, see note below
+VITE_CONTRACT_ADDRESS_137=
 #Project ID
 VITE_WALLETCONNECT_PROJECT_ID=Your Project ID can be obtained from https://dashboard.reown.com/ 
 ```
+
+> ⚠️ Ethereum Classic and Polygon are left blank on purpose. Both still run the
+> v1 contract, which stores invoice payloads on-chain as strings and has no
+> public key registry, so it does not match the current ABI. The app treats any
+> non-empty address as supported, so filling these in would send calls those
+> contracts cannot decode. Populate them only after redeploying.
 > ⚠️ **Security Note:** Never commit `.env` files to version control. Keep your private keys secure.
 
 ## Deployed Contracts
+
+### Current (hash-based invoice storage)
+Stores only `keccak256` of the invoice data on-chain and exposes the public key
+registry. This is the deployment the frontend is configured against.
+- Ethereum Sepolia (11155111)
+```0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2```
+
 ### v1 (Mainnet Deployment — Jan 1)
+Stores the invoice payload on-chain as strings. Superseded, kept for reference.
 - Ethereum Sepolia (11155111)
 ```0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562```
 - Ethereum Classic (61)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,17 @@
 # env-copy
 
 #Ethereum Sepolia (11155111)
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
 
+# Left blank deliberately. Both chains still run the v1 contract, which stores
+# invoice payloads on-chain as strings and has no public key registry, so it
+# does not match this ABI. The app treats any non-empty address as a supported
+# network, so filling these in would send bytes32-encoded calls to a contract
+# that cannot decode them. Populate them only after redeploying.
 # Ethereum Classic (61)
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_61=
 
 # Polygon Mainnet (137)
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_137=
 
 VITE_WALLETCONNECT_PROJECT_ID=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,11 +55,16 @@ The frontend reads Vite environment variables from `.env`.
 The provided `.env.example` includes deployed contract addresses for supported networks and the WalletConnect project ID placeholder:
 
 ```env
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
+VITE_CONTRACT_ADDRESS_61=
+VITE_CONTRACT_ADDRESS_137=
 VITE_WALLETCONNECT_PROJECT_ID=
 ```
+
+> ⚠️ Ethereum Classic and Polygon are left blank on purpose. Both still run the
+> v1 contract, which does not match the current ABI. The app treats any
+> non-empty address as supported, so filling these in would send calls those
+> contracts cannot decode. Populate them only after redeploying.
 
 To enable Web3 wallet functionality, create a free WalletConnect Project ID from the Reown dashboard:
 

--- a/frontend/src/contractsABI/ChainvoiceABI.js
+++ b/frontend/src/contractsABI/ChainvoiceABI.js
@@ -77,14 +77,9 @@ export const ChainvoiceABI = [
         "internalType": "address"
       },
       {
-        "name": "encryptedInvoiceData",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "encryptedHash",
-        "type": "string",
-        "internalType": "string"
+        "name": "invoiceDataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [],
@@ -110,14 +105,9 @@ export const ChainvoiceABI = [
         "internalType": "address"
       },
       {
-        "name": "encryptedPayloads",
-        "type": "string[]",
-        "internalType": "string[]"
-      },
-      {
-        "name": "encryptedHashes",
-        "type": "string[]",
-        "internalType": "string[]"
+        "name": "invoiceDataHashes",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
       }
     ],
     "outputs": [],
@@ -188,14 +178,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -288,14 +273,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -354,14 +334,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -447,14 +422,9 @@ export const ChainvoiceABI = [
         "internalType": "bool"
       },
       {
-        "name": "encryptedInvoiceData",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "encryptedHash",
-        "type": "string",
-        "internalType": "string"
+        "name": "invoiceDataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "stateMutability": "view"
@@ -607,25 +577,6 @@ export const ChainvoiceABI = [
         "name": "",
         "type": "address",
         "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "wakuPublicKeys",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes",
-        "internalType": "bytes"
       }
     ],
     "stateMutability": "view"


### PR DESCRIPTION
###  Addressed Issues:

Part of #139 (1 of 5). Does not close it on its own.


###  Screenshots/Recordings:

Not applicable — no user-visible change. This PR only realigns the ABI with the contract source.


###  Additional Notes:

The frontend ABI still described the pre-migration contract, which stored the full invoice payload on-chain as two strings:

```
createInvoice(address, uint256, address, string, string)
```

`contracts/src/Chainvoice.sol` has since moved to storing only a keccak256 commitment of the invoice data, and gained the public key registry:

```
createInvoice(address, uint256, address, bytes32)
```

Regenerated from `forge build` output so the ABI matches the contract source exactly. This also drops the `wakuPublicKeys` accessor, which is now a private mapping read through `getWakuPublicKey`.

`.env.example` pointed at `0x54a5…`, the old contract, where `getWakuPublicKey` reverts and `getInvoice` returns strings — following the setup docs would have produced an ABI/contract mismatch. Ethereum Classic and Polygon still run the old contract and are flagged inline as needing redeployment.

**Why it is separate:** this is a mechanical regeneration with no behaviour of its own. Splitting it out keeps the transport migration reviewable without an 850-line ABI diff in the middle of it.

**Review order:** must land together with #195 — on its own it leaves callers passing the old string arguments to a 4-argument function. Order: this → #194 → #195.

### AI Usage Disclosure:

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: **Claude Code (CLI), model Claude Opus 5**


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated invoice creation and batch creation to use a single invoice data hash.
  * Updated invoice details and invoice lists to display the new data hash format.

* **Bug Fixes**
  * Updated the Sepolia contract configuration for compatibility with the current application interface.
  * Removed the outdated public-key contract entry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->