### PR TITLE
feat: deliver invoice payloads over the relay instead of on-chain

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -45,11 +45,28 @@ jobs:
       - name: Build
         run: npm run build
         working-directory: ./frontend
-        env: 
+        env:
           VITE_WALLETCONNECT_PROJECT_ID: ${{ secrets.VITE_WALLETCONNECT_PROJECT_ID }}
           VITE_CONTRACT_ADDRESS_11155111: ${{ secrets.VITE_CONTRACT_ADDRESS_11155111 }}
-          VITE_CONTRACT_ADDRESS_61: ${{ secrets.VITE_CONTRACT_ADDRESS_61 }}
-          VITE_CONTRACT_ADDRESS_137: ${{ secrets.VITE_CONTRACT_ADDRESS_137 }}
+          # Ethereum Classic and Polygon are deliberately not injected. Both
+          # still run the v1 contract, which stores payloads on-chain as strings
+          # and has no key registry, so it does not match this ABI. The app
+          # treats any non-empty address as a supported network, so a populated
+          # secret here would publish a build that sends undecodable calls.
+          # Restore these once those chains are redeployed.
+          # Vite inlines these at build time, so an unset VITE_RELAY_URL bakes
+          # in the localhost fallback, which the browser then blocks as mixed
+          # content from the Pages origin. Either an https URL (needs CORS on
+          # the relay) or a path the host rewrites to it.
+          #
+          # Repository *variables*, not secrets: everything here is published in
+          # the JavaScript bundle, and storing a published value as a secret
+          # invites someone to put a privileged relay key in it. A static site
+          # cannot hold a credential — if the relay needs a private key, put a
+          # proxy in front and inject it there.
+          VITE_RELAY_URL: ${{ vars.VITE_RELAY_URL }}
+          VITE_RELAY_API_KEY: ${{ vars.VITE_RELAY_API_KEY }}
+          VITE_RELAY_TIMEOUT_MS: ${{ vars.VITE_RELAY_TIMEOUT_MS }}
 
       # Setup Pages
       - name: Setup Pages

--- a/README.md
+++ b/README.md
@@ -161,6 +161,21 @@ VITE_WALLETCONNECT_PROJECT_ID=Your Project ID can be obtained from https://dashb
 > contracts cannot decode. Populate them only after redeploying.
 > ⚠️ **Security Note:** Never commit `.env` files to version control. Keep your private keys secure.
 
+### Relay configuration
+
+Invoice payloads travel encrypted over a [ThruBox](https://github.com/AOSSIE-Org/ThruBox-Server) relay, configured with:
+
+```env
+VITE_RELAY_URL=http://localhost:3000
+VITE_RELAY_API_KEY=
+VITE_RELAY_TIMEOUT_MS=
+```
+
+- **`VITE_RELAY_URL`** — in development this is the target the Vite dev server proxies `/relay` to, so the browser stays same-origin. In production, either an absolute `https://` URL (which requires CORS on the relay) or a path such as `/relay` that your host rewrites to it (Vercel rewrites, Netlify redirects, nginx `proxy_pass`), which avoids CORS entirely.
+- **`VITE_RELAY_API_KEY`** — only needed if the relay sets `security.api_key`. **This is not a secret:** Vite inlines every `VITE_`-prefixed variable into the built JavaScript, so any visitor can read it. Treat it as a spam speed-bump, not access control. To keep a relay key private, proxy relay calls server-side and inject it there.
+- **`VITE_RELAY_TIMEOUT_MS`** — request timeout, default `15000`. Raise it (around `60000`) on hosts that suspend idle instances: a cold start can take most of a minute, and sends are deliberately not retried, so a timeout means an undelivered invoice.
+
+
 ## Deployed Contracts
 
 ### Current (hash-based invoice storage)

--- a/README.md
+++ b/README.md
@@ -145,18 +145,32 @@ npm run dev
 ### Frontend Configuration (`frontend/.env`)  
 ```.env
 #Ethereum Sepolia (11155111)
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
-#Ethereum Classic (61)
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
-#Polygon Mainnet (137)
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
+#Ethereum Classic (61) — blank until redeployed, see note below
+VITE_CONTRACT_ADDRESS_61=
+#Polygon Mainnet (137) — blank until redeployed, see note below
+VITE_CONTRACT_ADDRESS_137=
 #Project ID
 VITE_WALLETCONNECT_PROJECT_ID=Your Project ID can be obtained from https://dashboard.reown.com/ 
 ```
+
+> ⚠️ Ethereum Classic and Polygon are left blank on purpose. Both still run the
+> v1 contract, which stores invoice payloads on-chain as strings and has no
+> public key registry, so it does not match the current ABI. The app treats any
+> non-empty address as supported, so filling these in would send calls those
+> contracts cannot decode. Populate them only after redeploying.
 > ⚠️ **Security Note:** Never commit `.env` files to version control. Keep your private keys secure.
 
 ## Deployed Contracts
+
+### Current (hash-based invoice storage)
+Stores only `keccak256` of the invoice data on-chain and exposes the public key
+registry. This is the deployment the frontend is configured against.
+- Ethereum Sepolia (11155111)
+```0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2```
+
 ### v1 (Mainnet Deployment — Jan 1)
+Stores the invoice payload on-chain as strings. Superseded, kept for reference.
 - Ethereum Sepolia (11155111)
 ```0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562```
 - Ethereum Classic (61)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,12 +1,17 @@
 # env-copy
 
 #Ethereum Sepolia (11155111)
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
 
+# Left blank deliberately. Both chains still run the v1 contract, which stores
+# invoice payloads on-chain as strings and has no public key registry, so it
+# does not match this ABI. The app treats any non-empty address as a supported
+# network, so filling these in would send bytes32-encoded calls to a contract
+# that cannot decode them. Populate them only after redeploying.
 # Ethereum Classic (61)
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_61=
 
 # Polygon Mainnet (137)
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_137=
 
 VITE_WALLETCONNECT_PROJECT_ID=

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -15,3 +15,26 @@ VITE_CONTRACT_ADDRESS_61=
 VITE_CONTRACT_ADDRESS_137=
 
 VITE_WALLETCONNECT_PROJECT_ID=
+
+# ThruBox relay — transport for encrypted invoice payloads.
+# In development this is the target the Vite dev server proxies /relay to.
+#
+# In production, either:
+#   - an absolute URL (https://relay.example.com) — needs CORS on the relay, or
+#   - a path (/relay) — the host rewrites it to the relay, so the browser stays
+#     same-origin and no CORS is needed. Works with Vercel rewrites, Netlify
+#     redirects, or an nginx proxy_pass.
+VITE_RELAY_URL=http://localhost:3000
+
+# Only needed if the relay is configured with security.api_key. Leave blank otherwise.
+#
+# NOT A SECRET. Vite inlines every VITE_-prefixed variable into the built
+# JavaScript, so anyone can read this out of the bundle. Treat it as a spam
+# speed-bump, not access control — it cannot restrict the relay to this app.
+# To keep a relay key private, proxy relay calls server-side (see VITE_RELAY_URL
+# above) and inject the key there instead of shipping it to the browser.
+VITE_RELAY_API_KEY=
+
+# Request timeout in ms (default 15000). Raise it on hosts that suspend idle
+# instances — a cold start can take ~60s, and sends are not retried.
+VITE_RELAY_TIMEOUT_MS=

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -65,6 +65,19 @@ VITE_WALLETCONNECT_PROJECT_ID=
 > v1 contract, which does not match the current ABI. The app treats any
 > non-empty address as supported, so filling these in would send calls those
 > contracts cannot decode. Populate them only after redeploying.
+### Relay configuration
+
+Invoice payloads travel encrypted over a [ThruBox](https://github.com/AOSSIE-Org/ThruBox-Server) relay, configured with:
+
+```env
+VITE_RELAY_URL=http://localhost:3000
+VITE_RELAY_API_KEY=
+VITE_RELAY_TIMEOUT_MS=
+```
+
+- **`VITE_RELAY_URL`** — in development this is the target the Vite dev server proxies `/relay` to, so the browser stays same-origin. In production, either an absolute `https://` URL (which requires CORS on the relay) or a path such as `/relay` that your host rewrites to it (Vercel rewrites, Netlify redirects, nginx `proxy_pass`), which avoids CORS entirely.
+- **`VITE_RELAY_API_KEY`** — only needed if the relay sets `security.api_key`. **This is not a secret:** Vite inlines every `VITE_`-prefixed variable into the built JavaScript, so any visitor can read it. Treat it as a spam speed-bump, not access control. To keep a relay key private, proxy relay calls server-side and inject it there.
+- **`VITE_RELAY_TIMEOUT_MS`** — request timeout, default `15000`. Raise it (around `60000`) on hosts that suspend idle instances: a cold start can take most of a minute, and sends are deliberately not retried, so a timeout means an undelivered invoice.
 
 To enable Web3 wallet functionality, create a free WalletConnect Project ID from the Reown dashboard:
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -55,11 +55,16 @@ The frontend reads Vite environment variables from `.env`.
 The provided `.env.example` includes deployed contract addresses for supported networks and the WalletConnect project ID placeholder:
 
 ```env
-VITE_CONTRACT_ADDRESS_11155111=0x54a542dCDC306eE281b5De4613EcEfe6e6ABc562
-VITE_CONTRACT_ADDRESS_61=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
-VITE_CONTRACT_ADDRESS_137=0xD044A85a5daC307217B9bF313A90E8a60AF7DdCe
+VITE_CONTRACT_ADDRESS_11155111=0x7bC4C5abb5b1B8355Aa65307C1cFDbe6254505d2
+VITE_CONTRACT_ADDRESS_61=
+VITE_CONTRACT_ADDRESS_137=
 VITE_WALLETCONNECT_PROJECT_ID=
 ```
+
+> ⚠️ Ethereum Classic and Polygon are left blank on purpose. Both still run the
+> v1 contract, which does not match the current ABI. The app treats any
+> non-empty address as supported, so filling these in would send calls those
+> contracts cannot decode. Populate them only after redeploying.
 
 To enable Web3 wallet functionality, create a free WalletConnect Project ID from the Reown dashboard:
 

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -5,6 +5,9 @@ module.exports = {
   collectCoverageFrom: [
     "src/utils/invoiceCalculations.js",
     "src/utils/invoiceValidation.js",
+    "src/services/relay/invoiceCrypto.js",
+    "src/services/relay/invoiceHashUtils.js",
+    "src/services/relay/relayInvoiceMessaging.js",
   ],
   coverageDirectory: "<rootDir>/coverage",
 };

--- a/frontend/jest.config.cjs
+++ b/frontend/jest.config.cjs
@@ -8,6 +8,7 @@ module.exports = {
     "src/services/relay/invoiceCrypto.js",
     "src/services/relay/invoiceHashUtils.js",
     "src/services/relay/relayInvoiceMessaging.js",
+    "src/services/relay/relayKeyManager.js",
   ],
   coverageDirectory: "<rootDir>/coverage",
 };

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aossie-org/idb-backup": "^1.0.0",
+    "@aossie-org/thrubox-client": "1.0.2",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@mui/icons-material": "^6.4.6",
@@ -31,6 +32,7 @@
     "clsx": "^2.1.1",
     "crypto-convert": "^2.1.7",
     "date-fns": "^3.6.0",
+    "eciesjs": "0.5.0",
     "ethers": "^6.13.5",
     "framer-motion": "^12.23.12",
     "html2canvas": "^1.4.1",

--- a/frontend/src/contractsABI/ChainvoiceABI.js
+++ b/frontend/src/contractsABI/ChainvoiceABI.js
@@ -77,14 +77,9 @@ export const ChainvoiceABI = [
         "internalType": "address"
       },
       {
-        "name": "encryptedInvoiceData",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "encryptedHash",
-        "type": "string",
-        "internalType": "string"
+        "name": "invoiceDataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "outputs": [],
@@ -110,14 +105,9 @@ export const ChainvoiceABI = [
         "internalType": "address"
       },
       {
-        "name": "encryptedPayloads",
-        "type": "string[]",
-        "internalType": "string[]"
-      },
-      {
-        "name": "encryptedHashes",
-        "type": "string[]",
-        "internalType": "string[]"
+        "name": "invoiceDataHashes",
+        "type": "bytes32[]",
+        "internalType": "bytes32[]"
       }
     ],
     "outputs": [],
@@ -188,14 +178,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -288,14 +273,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -354,14 +334,9 @@ export const ChainvoiceABI = [
             "internalType": "bool"
           },
           {
-            "name": "encryptedInvoiceData",
-            "type": "string",
-            "internalType": "string"
-          },
-          {
-            "name": "encryptedHash",
-            "type": "string",
-            "internalType": "string"
+            "name": "invoiceDataHash",
+            "type": "bytes32",
+            "internalType": "bytes32"
           }
         ]
       }
@@ -447,14 +422,9 @@ export const ChainvoiceABI = [
         "internalType": "bool"
       },
       {
-        "name": "encryptedInvoiceData",
-        "type": "string",
-        "internalType": "string"
-      },
-      {
-        "name": "encryptedHash",
-        "type": "string",
-        "internalType": "string"
+        "name": "invoiceDataHash",
+        "type": "bytes32",
+        "internalType": "bytes32"
       }
     ],
     "stateMutability": "view"
@@ -607,25 +577,6 @@ export const ChainvoiceABI = [
         "name": "",
         "type": "address",
         "internalType": "address"
-      }
-    ],
-    "stateMutability": "view"
-  },
-  {
-    "type": "function",
-    "name": "wakuPublicKeys",
-    "inputs": [
-      {
-        "name": "",
-        "type": "address",
-        "internalType": "address"
-      }
-    ],
-    "outputs": [
-      {
-        "name": "",
-        "type": "bytes",
-        "internalType": "bytes"
       }
     ],
     "stateMutability": "view"

--- a/frontend/src/hooks/useRelayKeys.js
+++ b/frontend/src/hooks/useRelayKeys.js
@@ -1,0 +1,229 @@
+import { useState, useCallback, useEffect, useRef } from 'react';
+import { useAccount, useWalletClient } from 'wagmi';
+import { BrowserProvider, Contract } from 'ethers';
+import { ChainvoiceABI } from '../contractsABI/ChainvoiceABI.js';
+import {
+  deriveRelayKeyPair,
+  registerPublicKeyOnChain,
+  fetchPublicKeyFromChain,
+  bytesToHex,
+  getCachedKeyPair,
+  clearCachedKeys,
+} from '../services/relay/relayKeyManager.js';
+
+/**
+ * React hook for managing the user's ECIES messaging keypair.
+ * Handles derivation from a wallet signature, session caching,
+ * and on-chain registration status.
+ */
+export function useRelayKeys() {
+  const { data: walletClient } = useWalletClient();
+  const { address, chainId } = useAccount();
+  const [keys, setKeys] = useState(null);
+  const [hasKeys, setHasKeys] = useState(false);
+  const [isRegistered, setIsRegistered] = useState(false);
+  const [isUnsupportedNetwork, setIsUnsupportedNetwork] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState(null);
+  // Persist to sessionStorage by default. Without this the private key lives
+  // only in module memory, so a page reload silently loses it and anything
+  // gated on key availability — like polling the relay for new invoices —
+  // never starts again. sessionStorage still dies with the tab.
+  const [rememberSession, setRememberSession] = useState(true);
+
+  // Always the address of the currently connected account, readable from
+  // inside in-flight async work to tell whether its result is still wanted.
+  // Written in an effect rather than during render: a render can be discarded
+  // without committing (StrictMode double-renders, for one), and recording an
+  // address the committed tree never used would make the staleness check
+  // discard results that are actually current.
+  const activeAddressRef = useRef(address);
+  useEffect(() => {
+    activeAddressRef.current = address;
+  }, [address]);
+
+  // Reset account-scoped state and republish any already-derived key in one
+  // pass. Reads the cache directly rather than going through
+  // deriveRelayKeyPair, which would fall through to signMessage when the cache
+  // is empty or corrupt and pop an unexplained signature prompt on page load.
+  useEffect(() => {
+    setIsRegistered(false);
+    setError(null);
+
+    const cached = address ? getCachedKeyPair(address) : null;
+    setKeys(cached);
+    setHasKeys(cached !== null);
+  }, [address]);
+
+  // Drop the stored key for an account the user has actually left — a
+  // disconnect, or a switch to a different account.
+  //
+  // Deliberately not an effect cleanup: cleanups also run on unmount, which
+  // would wipe the key on every route change, on any second consumer of this
+  // hook unmounting, and once immediately in StrictMode — throwing away the
+  // key the effect above had just restored, and defeating the reason for
+  // persisting it at all.
+  const previousAddressRef = useRef(address);
+  useEffect(() => {
+    const previous = previousAddressRef.current;
+    previousAddressRef.current = address;
+    if (previous && previous !== address) {
+      clearCachedKeys(previous);
+    }
+  }, [address]);
+
+  const getContract = useCallback(async () => {
+    if (!walletClient || !chainId) return null;
+    const provider = new BrowserProvider(walletClient);
+    const signer = await provider.getSigner();
+    const contractAddress = import.meta.env[`VITE_CONTRACT_ADDRESS_${chainId}`];
+    if (!contractAddress) return null;
+    return new Contract(contractAddress, ChainvoiceABI, signer);
+  }, [walletClient, chainId]);
+
+  /** Derive keys from wallet signature without registering on-chain. */
+  const deriveKeysOnly = useCallback(
+    async (remember) => {
+      if (!walletClient || !address) throw new Error('Wallet not connected');
+      const requestedAddress = address;
+      const provider = new BrowserProvider(walletClient);
+      const signer = await provider.getSigner();
+      const shouldRemember = remember !== undefined ? remember : rememberSession;
+      const keyPair = await deriveRelayKeyPair(signer, requestedAddress, shouldRemember);
+      // Signing takes as long as the user takes, so the account may have
+      // changed underneath us; publishing then would attach one account's key
+      // to another.
+      if (activeAddressRef.current !== requestedAddress) return keyPair;
+      setKeys(keyPair);
+      setHasKeys(true);
+      return keyPair;
+    },
+    [walletClient, address, rememberSession]
+  );
+
+  /** Check if the user's public key is registered on-chain. */
+  const checkRegistration = useCallback(async () => {
+    const requestedAddress = address;
+    // Reading the registry is an async chain call. If the user switches
+    // accounts while it is in flight, the resolved value describes the old
+    // account — applying it would report the previous account's registration
+    // state for the current one, and could skip the setup step for an address
+    // that has no key on chain.
+    const isStale = () => activeAddressRef.current !== requestedAddress;
+
+    // "No contract on this chain" is not the same as "not registered", and
+    // registering cannot fix it — report it separately so callers can say so
+    // rather than offering a setup step that is guaranteed to fail.
+    const unsupported =
+      Boolean(chainId) && !import.meta.env[`VITE_CONTRACT_ADDRESS_${chainId}`];
+    if (!isStale()) setIsUnsupportedNetwork(unsupported);
+    if (unsupported) {
+      if (!isStale()) setIsRegistered(false);
+      return false;
+    }
+
+    const contract = await getContract();
+    if (!contract || !requestedAddress) {
+      if (!isStale()) setIsRegistered(false);
+      return false;
+    }
+    try {
+      const pubKey = await fetchPublicKeyFromChain(contract, requestedAddress);
+      const registered = pubKey !== null && pubKey.length > 0;
+      if (!isStale()) setIsRegistered(registered);
+      return registered;
+    } catch (err) {
+      // A transient RPC failure is indistinguishable from "not registered" in
+      // the returned value, so leave a trace of which one it was.
+      console.warn('[useRelayKeys] Registry read failed:', err);
+      if (!isStale()) setIsRegistered(false);
+      return false;
+    }
+  }, [getContract, address, chainId]);
+
+  /** Derive keys AND register the public key on-chain (if not already). */
+  const deriveAndRegister = useCallback(
+    async (remember) => {
+      const requestedAddress = address;
+      // Abort rather than publish if the account changes mid-flow: the signer,
+      // the key being compared and the key being registered must all describe
+      // the same account.
+      const assertSameAccount = () => {
+        if (activeAddressRef.current !== requestedAddress) {
+          throw new Error('Account changed during key registration');
+        }
+      };
+
+      try {
+        setIsLoading(true);
+        setError(null);
+
+        const keyPair = await deriveKeysOnly(remember);
+        assertSameAccount();
+
+        const contract = await getContract();
+        if (!contract) throw new Error('Contract not available on this network');
+        assertSameAccount();
+
+        // Skip the transaction if the same key is already registered
+        const existingKey = await fetchPublicKeyFromChain(contract, requestedAddress);
+        assertSameAccount();
+        if (existingKey && existingKey.length > 0) {
+          if (bytesToHex(existingKey) === bytesToHex(keyPair.publicKey)) {
+            setIsRegistered(true);
+            return;
+          }
+        }
+
+        await registerPublicKeyOnChain(contract, keyPair.publicKey);
+        assertSameAccount();
+        setIsRegistered(true);
+      } catch (err) {
+        console.error('[useRelayKeys] Failed to derive/register keys:', err);
+        // The rejection value is whatever the wallet provider threw, which is
+        // not guaranteed to be an Error. Reading .message off a string or null
+        // would throw from inside this catch, losing the real failure and
+        // never running setError.
+        const rawMessage =
+          typeof err?.message === 'string' ? err.message : String(err ?? '');
+        const code = err?.code;
+        let errMsg = rawMessage || 'Failed to register messaging keys';
+        if (
+          errMsg.toLowerCase().includes('user rejected') ||
+          errMsg.toLowerCase().includes('rejected the request') ||
+          code === 'ACTION_REJECTED' ||
+          code === 4001
+        ) {
+          errMsg =
+            'Signature request rejected. You must sign the message to enable encrypted invoices.';
+        }
+        setError(errMsg);
+        throw err;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [deriveKeysOnly, getContract, address]
+  );
+
+  // Check registration status when wallet/chain changes
+  useEffect(() => {
+    if (address && walletClient && chainId) {
+      checkRegistration().catch(() => {});
+    }
+  }, [address, walletClient, chainId, checkRegistration]);
+
+  return {
+    keys,
+    hasKeys,
+    isRegistered,
+    isUnsupportedNetwork,
+    isLoading,
+    error,
+    rememberSession,
+    setRememberSession,
+    deriveAndRegister,
+    deriveKeysOnly,
+    checkRegistration,
+  };
+}

--- a/frontend/src/page/BatchPayment.jsx
+++ b/frontend/src/page/BatchPayment.jsx
@@ -7,7 +7,10 @@ import SwipeableDrawer from "@mui/material/SwipeableDrawer";
 import html2canvas from "html2canvas";
 
 import { ERC20_ABI } from "../contractsABI/ERC20_ABI";
+import { getReceivedInvoices as getLocalReceivedInvoices } from "../services/invoiceStorage/invoiceDB.js";
+import { verifyInvoiceHash } from "../services/relay/invoiceHashUtils.js";
 import toast from "react-hot-toast";
+import { resolveInvoiceDecimals, formatInvoiceDate } from "../utils/invoiceAmounts.js";
 import {
   CheckCircle2,
   Loader2,
@@ -24,6 +27,8 @@ import {
 } from "lucide-react";
 import { useTokenList } from "../hooks/useTokenList";
 import WalletConnectionAlert from "../components/WalletConnectionAlert";
+
+
 
 function BatchPayment() {
   const [page, setPage] = useState(0);
@@ -89,7 +94,11 @@ function BatchPayment() {
     const groups = invoices
       .filter((inv) => !inv.isPaid && !inv.isCancelled)
       .reduce((acc, inv) => {
-        const issueDate = new Date(inv.issueDate).toDateString();
+        // Undated on-chain-only invoices would otherwise all share the
+        // "Invalid Date" key and be suggested as one bogus batch.
+        const issueDate = inv.issueDate
+          ? new Date(inv.issueDate).toDateString()
+          : `undated-${inv.id}`;
         const key = `${inv.user?.address}_${
           inv.paymentToken?.address || "ETH"
         }_${issueDate}`;
@@ -320,6 +329,16 @@ function BatchPayment() {
 
         const decryptedInvoices = [];
 
+        // The payload lives in IndexedDB, delivered over the relay; the chain
+        // only holds a hash of it.
+        const localInvoices = await getLocalReceivedInvoices(address);
+        const localInvoiceMap = new Map();
+        for (const local of localInvoices) {
+          if (String(local.chainId) === String(chainId)) {
+            localInvoiceMap.set(String(local.invoiceId), local);
+          }
+        }
+
         for (const invoice of res) {
           try {
             const id = invoice[0];
@@ -327,19 +346,31 @@ function BatchPayment() {
             const to = invoice[2].toLowerCase();
             const isPaid = invoice[5];
             const isCancelled = invoice[6];
-            const encryptedStringBase64 = invoice[7];
-            const dataToEncryptHash = invoice[8];
-
-            if (!encryptedStringBase64 || !dataToEncryptHash) continue;
+            const invoiceDataHash = invoice[7];
 
             const currentUserAddress = address.toLowerCase();
             if (currentUserAddress !== from && currentUserAddress !== to) {
               continue;
             }
 
-            const decryptedString = atob(encryptedStringBase64);
+            const localInv = localInvoiceMap.get(id.toString());
+            // Only trust a payload that still matches its on-chain commitment.
+            const payloadTrusted =
+              localInv?.data && verifyInvoiceHash(localInv.data, invoiceDataHash);
 
-            const parsed = JSON.parse(decryptedString);
+            // Invoices whose details have not arrived are still payable: the
+            // amount and token come from the chain, which is authoritative.
+            const parsed = payloadTrusted
+              ? { ...localInv.data }
+              : {
+                  amountDue: invoice[3].toString(),
+                  user: { address: from },
+                  client: { address: to },
+                  paymentToken: { address: invoice[4] },
+                  issueDate: null,
+                  dueDate: null,
+                  _onChainOnly: true,
+                };
             parsed["id"] = id;
             parsed["isPaid"] = isPaid;
             parsed["isCancelled"] = isCancelled;
@@ -394,6 +425,21 @@ function BatchPayment() {
                     parsed.paymentToken.logo || "/tokenImages/generic.png";
                 }
               }
+            }
+
+            // On-chain amounts are raw token units; the stored payload carries
+            // an already-formatted decimal string, so only stubs need scaling.
+            if (parsed._onChainOnly) {
+              const decimals = resolveInvoiceDecimals(parsed.paymentToken);
+              if (decimals === null) {
+                // Showing a base-unit figure as if it were a token amount, or
+                // feeding it to parseUnits, is worse than omitting the invoice.
+                console.warn(
+                  `Invoice ${parsed.id}: cannot resolve token decimals, skipping`
+                );
+                continue;
+              }
+              parsed.amountDue = ethers.formatUnits(parsed.amountDue, decimals);
             }
 
             decryptedInvoices.push(parsed);
@@ -712,10 +758,7 @@ function BatchPayment() {
     )}`;
   };
 
-  const formatDate = (issueDate) => {
-    const date = new Date(issueDate);
-    return date.toLocaleString();
-  };
+  const formatDate = formatInvoiceDate;
 
   const unpaidInvoices = receivedInvoices.filter(
     (inv) => !inv.isPaid && !inv.isCancelled
@@ -1373,15 +1416,11 @@ function BatchPayment() {
                   <div className="flex justify-between text-sm text-gray-500 mb-2">
                     <span>
                       Issued:{" "}
-                      {new Date(
-                        drawerState.selectedInvoice.issueDate
-                      ).toLocaleDateString()}
+                      {formatInvoiceDate(drawerState.selectedInvoice.issueDate)}
                     </span>
                     <span>
                       Due:{" "}
-                      {new Date(
-                        drawerState.selectedInvoice.dueDate
-                      ).toLocaleDateString()}
+                      {formatInvoiceDate(drawerState.selectedInvoice.dueDate)}
                     </span>
                   </div>
                 </div>

--- a/frontend/src/page/CreateInvoice.jsx
+++ b/frontend/src/page/CreateInvoice.jsx
@@ -51,6 +51,9 @@ import {
 } from "@/utils/invoiceValidation";
 import toast from "react-hot-toast";
 import { storeInvoice } from "../services/invoiceStorage/invoiceDB.js";
+import { computeInvoiceHash } from "../services/relay/invoiceHashUtils.js";
+import { sendEncryptedInvoice } from "../services/relay/relayInvoiceMessaging.js";
+import { fetchPublicKeyFromChain } from "../services/relay/relayKeyManager.js";
 
 
 import { AmountTypeToggle } from "../components/AmountTypeToggle";
@@ -522,11 +525,10 @@ function CreateInvoice() {
         })),
       };
 
-      const invoiceString = JSON.stringify(invoicePayload);
-
-      // 2. Base64 Encode Payload
-      const encryptedStringBase64 = btoa(invoiceString);
-      const dataToEncryptHash = "";
+      // Only a commitment to the invoice goes on-chain. The payload itself
+      // reaches the client encrypted over the relay, and they recompute this
+      // hash to prove it arrived untampered.
+      const invoiceDataHash = computeInvoiceHash(invoicePayload);
 
       if (!account?.chainId) {
         throw new Error("Missing chainId: wallet connected but chain not configured");
@@ -546,8 +548,7 @@ function CreateInvoice() {
         normalizedData.clientAddress,
         ethers.parseUnits(totalAmountDue.toString(), tokenDecimals),
         paymentToken.address,
-        encryptedStringBase64,
-        dataToEncryptHash
+        invoiceDataHash
       );
 
       const receipt = await tx.wait();
@@ -566,7 +567,42 @@ function CreateInvoice() {
         }
       }
 
+      let relayDelivered = false;
       if (invoiceId) {
+        // Delivery is best-effort: the invoice already exists on-chain, and
+        // the client can still be sent the payload later.
+        try {
+          const receiverPublicKey = await fetchPublicKeyFromChain(
+            contract,
+            normalizedData.clientAddress
+          );
+          if (receiverPublicKey) {
+            await sendEncryptedInvoice({
+              invoiceData: invoicePayload,
+              receiverPublicKey,
+              receiverAddress: normalizedData.clientAddress,
+              senderAddress: account.address,
+              chainId: account.chainId,
+              invoiceId,
+            });
+            relayDelivered = true;
+          } else {
+            toast(
+              "Invoice created. Your client has not registered a messaging key yet, so they will only see the on-chain summary until they do.",
+              { icon: "ℹ️" }
+            );
+          }
+        } catch (relayErr) {
+          console.warn(
+            `Relay delivery for invoice ${invoiceId} failed (non-critical):`,
+            relayErr
+          );
+          toast(
+            "Invoice created on-chain, but delivering the encrypted details to your client failed. You can resend from Sent Invoices.",
+            { icon: "⚠️" }
+          );
+        }
+
         try {
           await storeInvoice({
             invoiceId,
@@ -575,8 +611,8 @@ function CreateInvoice() {
             to: data.clientAddress.toLowerCase(),
             isPaid: false,
             isCancelled: false,
-            wakuDelivered: false,
-            invoiceDataHash: dataToEncryptHash,
+            relayDelivered,
+            invoiceDataHash,
             data: invoicePayload,
           });
         } catch (storageErr) {
@@ -595,7 +631,14 @@ function CreateInvoice() {
 
       setTimeout(() => navigate("/dashboard/sent"), 4000);
     } catch (err) {
-      console.error("Encryption or transaction failed:", err);
+      // Declining in the wallet is a deliberate choice, not a failure — saying
+      // "Failed to create invoice" sends people hunting for a bug that is not
+      // there. MetaMask surfaces this as 4001, ethers as ACTION_REJECTED.
+      if (err?.code === "ACTION_REJECTED" || err?.code === 4001) {
+        toast("Transaction cancelled in your wallet.", { icon: "✋" });
+        return;
+      }
+      console.error("Invoice creation failed:", err);
       toast.error("Failed to create invoice.");
     } finally {
       setLoading(false);

--- a/frontend/src/page/CreateInvoicesBatch.jsx
+++ b/frontend/src/page/CreateInvoicesBatch.jsx
@@ -38,6 +38,9 @@ import { Label } from "@/components/ui/label";
 import { useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
 import { storeInvoice } from "../services/invoiceStorage/invoiceDB.js";
+import { computeInvoiceHash } from "../services/relay/invoiceHashUtils.js";
+import { sendEncryptedInvoice } from "../services/relay/relayInvoiceMessaging.js";
+import { fetchPublicKeyFromChain } from "../services/relay/relayKeyManager.js";
 
 
 
@@ -557,8 +560,7 @@ function CreateInvoicesBatch() {
       // Prepare batch arrays
       const tos = [];
       const amounts = [];
-      const encryptedPayloads = [];
-      const encryptedHashes = [];
+      const invoiceDataHashes = [];
 
 
 
@@ -569,7 +571,7 @@ function CreateInvoicesBatch() {
       // Process each invoice
       for (const [index, row] of validInvoices.entries()) {
         toast(
-          `Encrypting invoice ${index + 1} of ${validInvoices.length}...`
+          `Preparing invoice ${index + 1} of ${validInvoices.length}...`
         );
 
         const invoicePayload = {
@@ -612,11 +614,11 @@ function CreateInvoicesBatch() {
           },
         };
 
-        const invoiceString = JSON.stringify(invoicePayload);
         invoicePayloads.push(invoicePayload);
 
-        const encryptedStringBase64 = btoa(invoiceString);
-        const dataToEncryptHash = "";
+        // Only the commitment goes on-chain; the payload is delivered
+        // encrypted over the relay once the batch is confirmed.
+        const invoiceDataHash = computeInvoiceHash(invoicePayload);
 
         // Add to batch arrays
         tos.push(row.clientAddress);
@@ -634,11 +636,10 @@ function CreateInvoicesBatch() {
         }
 
         amounts.push(amountForContract);
-        encryptedPayloads.push(encryptedStringBase64);
-        encryptedHashes.push(dataToEncryptHash);
+        invoiceDataHashes.push(invoiceDataHash);
       }
 
-      toast.success("All invoices encrypted successfully!");
+      toast.success("All invoices prepared successfully!");
       toast("Submitting batch transaction to blockchain...");
 
       // Send to contract
@@ -656,49 +657,151 @@ function CreateInvoicesBatch() {
         tos,
         amounts,
         paymentToken.address,
-        encryptedPayloads,
-        encryptedHashes
+        invoiceDataHashes
       );
 
       toast("Transaction submitted! Waiting for confirmation...");
       const receipt = await tx.wait();
 
       const iface = new ethers.Interface(ChainvoiceABI);
-      const invoiceIds = [];
+      // Keep the recipient alongside each id. Payloads are paired with events
+      // by position, and position is only meaningful if the recipient matches —
+      // pairing the wrong way round would encrypt one client's invoice to
+      // another client's key.
+      const created = [];
       for (const log of receipt.logs) {
         try {
           const parsed = iface.parseLog(log);
           if (parsed?.name === 'InvoiceCreated') {
-            invoiceIds.push(parsed.args[0].toString());
+            created.push({
+              id: parsed.args[0].toString(),
+              to: parsed.args[2].toLowerCase(),
+            });
           }
         } catch {
           // ignore
         }
       }
+      const invoiceIds = created.map((c) => c.id);
 
       if (invoiceIds.length !== invoicePayloads.length) {
         console.warn(`Expected ${invoicePayloads.length} InvoiceCreated events, got ${invoiceIds.length}`);
       }
 
-      for (const [eventIndex, invoiceId] of invoiceIds.entries()) {
+      // Deliver in bounded groups. A 50-invoice batch is 100 sequential round
+      // trips otherwise, all of it after the transaction has already confirmed,
+      // with the user watching a spinner. Kept small so the relay's per-IP rate
+      // limit is not the next thing to fail.
+      const DELIVERY_CONCURRENCY = 5;
+      let undelivered = 0;
+
+      let unmatched = 0;
+      const deliverOne = async (eventIndex) => {
+        const { id: invoiceId, to: eventTo } = created[eventIndex];
         const payload = invoicePayloads[eventIndex];
-        if (!payload) continue;
+        if (!payload) {
+          // The invoice exists on-chain but we have no payload to pair with it,
+          // so nothing is stored and nothing can be delivered. Silence here
+          // would hand the user a success toast for an invoice whose details
+          // were never captured.
+          console.error(
+            `Invoice ${invoiceId}: no local payload for this event; details not captured`
+          );
+          unmatched++;
+          return;
+        }
+
+        const payloadTo = payload.client.address.toLowerCase();
+        if (eventTo !== payloadTo) {
+          // Positions disagree with the chain. Encrypting to the wrong
+          // recipient would disclose the invoice, so store locally and let the
+          // sender resend rather than guess.
+          console.error(
+            `Invoice ${invoiceId}: event recipient ${eventTo} does not match payload recipient ${payloadTo}; skipping relay delivery`
+          );
+          undelivered++;
+          try {
+            await storeInvoice({
+              invoiceId,
+              chainId: account.chainId,
+              from: account.address.toLowerCase(),
+              to: payloadTo,
+              isPaid: false,
+              isCancelled: false,
+              relayDelivered: false,
+              invoiceDataHash: invoiceDataHashes[eventIndex],
+              data: payload,
+            });
+          } catch (err) {
+            console.error(`Failed to store invoice ${invoiceId} locally:`, err);
+          }
+          return;
+        }
+
+        // Delivery is best-effort and per-recipient: one client without a
+        // registered key must not stop the rest of the batch from arriving.
+        let relayDelivered = false;
+        try {
+          const receiverPublicKey = await fetchPublicKeyFromChain(
+            contract,
+            payload.client.address
+          );
+          if (receiverPublicKey) {
+            await sendEncryptedInvoice({
+              invoiceData: payload,
+              receiverPublicKey,
+              receiverAddress: payload.client.address,
+              senderAddress: account.address,
+              chainId: account.chainId,
+              invoiceId,
+            });
+            relayDelivered = true;
+          }
+        } catch (relayErr) {
+          console.warn(
+            `Relay delivery for invoice ${invoiceId} failed (non-critical):`,
+            relayErr
+          );
+        }
+        if (!relayDelivered) undelivered++;
 
         try {
           await storeInvoice({
             invoiceId,
             chainId: account.chainId,
             from: account.address.toLowerCase(),
-            to: payload.client.address.toLowerCase(),
+            to: payloadTo,
             isPaid: false,
             isCancelled: false,
-            wakuDelivered: false,
-            invoiceDataHash: "",
+            relayDelivered,
+            invoiceDataHash: invoiceDataHashes[eventIndex],
             data: payload,
           });
         } catch (err) {
           console.error(`Failed to store invoice ${invoiceId} locally:`, err);
         }
+      };
+
+      for (let i = 0; i < created.length; i += DELIVERY_CONCURRENCY) {
+        const group = [];
+        for (let j = i; j < Math.min(i + DELIVERY_CONCURRENCY, created.length); j++) {
+          group.push(deliverOne(j));
+        }
+        await Promise.all(group);
+      }
+
+      if (undelivered > 0) {
+        toast(
+          `${undelivered} of ${invoiceIds.length} invoices could not be delivered to the client yet. Resend them from Sent Invoices.`,
+          { icon: "⚠️" }
+        );
+      }
+
+      if (unmatched > 0) {
+        toast.error(
+          `${unmatched} of ${invoiceIds.length} invoices were created on-chain but their details could not be matched locally. Those invoices are payable but their details are lost — please re-create them.`,
+          { duration: 12000 }
+        );
       }
 
       toast.success(

--- a/frontend/src/page/ReceivedInvoice.jsx
+++ b/frontend/src/page/ReceivedInvoice.jsx
@@ -8,17 +8,21 @@ import TablePagination from "@mui/material/TablePagination";
 import TableRow from "@mui/material/TableRow";
 import { ChainvoiceABI } from "@/contractsABI/ChainvoiceABI";
 import { BrowserProvider, Contract, ethers } from "ethers";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAccount, useWalletClient } from "wagmi";
 import DescriptionIcon from "@mui/icons-material/Description";
 import SwipeableDrawer from "@mui/material/SwipeableDrawer";
 import { generateInvoicePDF } from "@/utils/generateInvoicePDF";
 import { formatInvoiceTotal } from "@/utils/invoiceExportHelpers";
 import { useInvoiceExport } from "@/hooks/useInvoiceExport";
-import { getReceivedInvoices as getLocalReceivedInvoices, storeInvoice, updateInvoiceStatus } from "../services/invoiceStorage/invoiceDB.js";
+import { getReceivedInvoices as getLocalReceivedInvoices, getInvoiceById, storeInvoice, updateInvoiceStatus } from "../services/invoiceStorage/invoiceDB.js";
+import { verifyInvoiceHash } from "@/services/relay/invoiceHashUtils.js";
+import { fetchInvoiceMessages, pollInvoiceMessages } from "@/services/relay/relayInvoiceMessaging.js";
+import { useRelayKeys } from "@/hooks/useRelayKeys";
 
 import { ERC20_ABI } from "@/contractsABI/ERC20_ABI";
 import toast from "react-hot-toast";
+import { resolveInvoiceDecimals, formatInvoiceDate } from "@/utils/invoiceAmounts";
 import CancelIcon from "@mui/icons-material/Cancel";
 
 import {
@@ -55,6 +59,7 @@ import LightbulbIcon from "@mui/icons-material/Lightbulb";
 import LayersIcon from "@mui/icons-material/Layers";
 import CloseIcon from "@mui/icons-material/Close";
 import ErrorIcon from "@mui/icons-material/Error";
+import WarningIcon from "@mui/icons-material/Warning";
 import { useTokenList } from "@/hooks/useTokenList";
 import WalletConnectionAlert from "@/components/WalletConnectionAlert";
 
@@ -67,6 +72,8 @@ const columns = [
   { id: "date", label: "Date", minWidth: 100 },
   { id: "actions", label: "Actions", minWidth: 150 },
 ];
+
+
 
 function ReceivedInvoice() {
   const [page, setPage] = useState(0);
@@ -85,6 +92,17 @@ function ReceivedInvoice() {
 
   const [paymentLoading, setPaymentLoading] = useState({});
   const [showWalletAlert, setShowWalletAlert] = useState(!isConnected);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const {
+    keys,
+    isRegistered,
+    isUnsupportedNetwork,
+    isLoading: keysLoading,
+    error: keysError,
+    deriveAndRegister,
+    deriveKeysOnly,
+  } = useRelayKeys();
+  const relayStopRef = useRef(null);
 
   // Error handling states
   const [paymentError, setPaymentError] = useState("");
@@ -206,7 +224,11 @@ function ReceivedInvoice() {
     const groups = invoices
       .filter((inv) => !inv.isPaid && !inv.isCancelled)
       .reduce((acc, inv) => {
-        const issueDate = new Date(inv.issueDate).toDateString();
+        // Undated on-chain-only invoices would otherwise all share the
+        // "Invalid Date" key and be suggested as one bogus batch.
+        const issueDate = inv.issueDate
+          ? new Date(inv.issueDate).toDateString()
+          : `undated-${inv.id}`;
         const key = `${inv.user?.address}_${inv.paymentToken?.address || "ETH"
           }_${issueDate}`;
         if (!acc[key]) acc[key] = [];
@@ -673,10 +695,7 @@ function ReceivedInvoice() {
             const to = invoice[2].toLowerCase();
             const isPaid = invoice[5];
             const isCancelled = invoice[6];
-            const encryptedStringBase64 = invoice[7];
-            const dataToEncryptHash = invoice[8];
-
-            if (!encryptedStringBase64 || !dataToEncryptHash) continue;
+            const invoiceDataHash = invoice[7];
 
             const currentUserAddress = address.toLowerCase();
             if (currentUserAddress !== from && currentUserAddress !== to) {
@@ -686,34 +705,39 @@ function ReceivedInvoice() {
             const localInv = localInvoiceMap.get(id);
             let parsed;
 
-            if (localInv && localInv.data) {
+            // The payload lives only in IndexedDB, delivered over the relay.
+            // Recompute its hash and compare against the chain: a payload that
+            // does not match the sender's on-chain commitment is not trusted,
+            // and we fall back to the on-chain facts instead of showing it.
+            const payloadTrusted =
+              localInv?.data && verifyInvoiceHash(localInv.data, invoiceDataHash);
+
+            if (payloadTrusted) {
               parsed = { ...localInv.data };
-              
+
               // Update local status if it changed
               if (localInv.isPaid !== isPaid || localInv.isCancelled !== isCancelled) {
                 await updateInvoiceStatus(chainId, id, { isPaid, isCancelled });
               }
             } else {
-              if (!encryptedStringBase64) continue;
-              const decryptedString = atob(encryptedStringBase64);
-              parsed = JSON.parse(decryptedString);
-
-              // Cache it locally
-              try {
-                await storeInvoice({
-                  invoiceId: id,
-                  chainId,
-                  from,
-                  to,
-                  isPaid,
-                  isCancelled,
-                  wakuDelivered: false,
-                  invoiceDataHash: dataToEncryptHash,
-                  data: parsed
-                });
-              } catch (err) {
-                console.warn(`Failed to cache invoice ${id} locally`, err);
+              if (localInv?.data) {
+                console.warn(
+                  `Invoice ${id}: stored payload does not match the on-chain hash; showing on-chain data only`
+                );
               }
+              // Either nothing has arrived over the relay yet, or what did
+              // arrive failed verification. Build a stub from on-chain data so
+              // the invoice is still visible and payable.
+              parsed = {
+                amountDue: invoice[3].toString(),
+                user: { address: from },
+                client: { address: to },
+                paymentToken: { address: invoice[4] },
+                issueDate: null,
+                dueDate: null,
+                _onChainOnly: true,
+                _hashMismatch: Boolean(localInv?.data),
+              };
             }
 
             parsed["id"] = BigInt(id);
@@ -769,6 +793,21 @@ function ReceivedInvoice() {
               }
             }
 
+            // On-chain amounts are raw token units; the relay payload carries
+            // an already-formatted decimal string, so only stubs need scaling.
+            if (parsed._onChainOnly) {
+              const decimals = resolveInvoiceDecimals(parsed.paymentToken);
+              if (decimals === null) {
+                // Showing a base-unit figure as if it were a token amount, or
+                // feeding it to parseUnits, is worse than omitting the invoice.
+                console.warn(
+                  `Invoice ${parsed.id}: cannot resolve token decimals, skipping`
+                );
+                continue;
+              }
+              parsed.amountDue = ethers.formatUnits(parsed.amountDue, decimals);
+            }
+
             decryptedInvoices.push(parsed);
           } catch (err) {
             console.error(`Error processing invoice ${invoice[0]}:`, err);
@@ -793,7 +832,139 @@ function ReceivedInvoice() {
 
     fetchReceivedInvoices();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [walletClient, address, tokens, chainId]);
+  }, [walletClient, address, tokens, chainId, refreshTrigger]);
+
+  // Relay ingestion runs independently of the display fetch above. Keeping it
+  // out of the refreshTrigger cycle matters: if storing a message re-ran this
+  // effect, it would re-fetch the same mailbox, store the same invoices and
+  // bump the trigger again, forever.
+  //
+  // It keys off `keys` from the hook rather than probing the key cache
+  // directly, so that unlocking or registering starts polling immediately
+  // instead of only after some unrelated dependency happens to change.
+  useEffect(() => {
+    if (!isConnected || !address || !chainId || !walletClient) return;
+    if (!keys?.privateKey) return;
+
+    let cancelled = false;
+
+    const contractAddress = import.meta.env[`VITE_CONTRACT_ADDRESS_${chainId}`];
+    if (!contractAddress) return;
+    const contract = new Contract(
+      contractAddress,
+      ChainvoiceABI,
+      new BrowserProvider(walletClient)
+    );
+
+
+    /**
+     * Persist a relay invoice, reporting whether it was genuinely new.
+     * The relay has no cursor, so the same message is re-read on every poll;
+     * only unseen invoices should wake the UI.
+     *
+     * The envelope is checked against the on-chain commitment before it is
+     * stored. Anyone can encrypt to this recipient — the public key is in the
+     * registry — so without that check a stranger could post an envelope
+     * claiming any invoice id, have it stored first, and permanently shadow
+     * the real payload: the record would exist, so the genuine delivery would
+     * be skipped as a duplicate and the invoice would sit unverifiable for good.
+     */
+    const storeRelayInvoice = async ({ envelope }) => {
+      const sender = envelope.data?.user?.address;
+      if (!sender) {
+        console.warn("[ReceivedInvoice] Relay envelope has no sender address");
+        return false;
+      }
+      try {
+        if (Number(envelope.chainId) !== Number(chainId)) return false;
+
+        const onChain = await contract.getInvoice(envelope.invoiceId);
+        // Only the addressee may store an invoice, and it must be this account.
+        if (onChain[2].toLowerCase() !== address.toLowerCase()) {
+          console.warn(
+            `[ReceivedInvoice] Envelope for invoice ${envelope.invoiceId} is not addressed to this account; ignoring`
+          );
+          return false;
+        }
+        if (!verifyInvoiceHash(envelope.data, onChain[7])) {
+          console.warn(
+            `[ReceivedInvoice] Envelope for invoice ${envelope.invoiceId} does not match the on-chain hash; ignoring`
+          );
+          return false;
+        }
+
+        // Verified payloads may replace an unverified record, so an earlier
+        // bogus delivery cannot lock the real one out.
+        const existing = await getInvoiceById(envelope.chainId, envelope.invoiceId);
+        if (existing?.data && verifyInvoiceHash(existing.data, onChain[7])) {
+          return false;
+        }
+
+        await storeInvoice({
+          invoiceId: envelope.invoiceId,
+          chainId: envelope.chainId,
+          from: sender,
+          to: address,
+          isPaid: existing?.isPaid ?? false,
+          isCancelled: existing?.isCancelled ?? false,
+          data: envelope.data,
+        });
+        return true;
+      } catch (err) {
+        console.error("[ReceivedInvoice] Failed to store relay invoice:", err);
+        return false;
+      }
+    };
+
+    const startRelay = async () => {
+      try {
+        const { privateKey } = keys;
+
+        const pending = await fetchInvoiceMessages({
+          privateKey,
+          address,
+          chainId,
+        });
+        if (cancelled) return;
+
+        let stored = 0;
+        for (const item of pending) {
+          if (cancelled) return;
+          if (await storeRelayInvoice(item)) stored++;
+        }
+        if (stored > 0 && !cancelled) setRefreshTrigger((p) => p + 1);
+
+        const stop = pollInvoiceMessages({
+          privateKey,
+          address,
+          chainId,
+          knownMessageIds: pending.map((item) => item.messageId),
+          onInvoice: async (item) => {
+            if (cancelled) return;
+            if (await storeRelayInvoice(item)) {
+              setRefreshTrigger((p) => p + 1);
+              toast.success("New invoice received!");
+            }
+          },
+        });
+
+        if (cancelled) stop();
+        else relayStopRef.current = stop;
+      } catch (err) {
+        console.warn("[ReceivedInvoice] Relay setup failed:", err);
+      }
+    };
+
+    startRelay();
+
+    return () => {
+      cancelled = true;
+      if (typeof relayStopRef.current === "function") {
+        relayStopRef.current();
+        relayStopRef.current = null;
+      }
+    };
+  }, [isConnected, address, chainId, walletClient, keys]);
 
   const toggleDrawer = (invoice) => (event) => {
     if (
@@ -857,10 +1028,7 @@ function ReceivedInvoice() {
     )}`;
   };
 
-  const formatDate = (issueDate) => {
-    const date = new Date(issueDate);
-    return date.toLocaleString();
-  };
+  const formatDate = formatInvoiceDate;
 
   const unpaidInvoices = receivedInvoices.filter(
     (inv) => !inv.isPaid && !inv.isCancelled
@@ -889,6 +1057,73 @@ function ReceivedInvoice() {
               </p>
             </div>
           </div>
+
+          {/* Without a registered public key, senders have nothing to encrypt
+              to, so invoices arrive as on-chain summaries with no detail. */}
+          {isConnected && !isUnsupportedNetwork && !isRegistered && (
+            <Alert
+              severity="info"
+              sx={{ mb: 2 }}
+              action={
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={keysLoading}
+                  onClick={() =>
+                    deriveAndRegister().catch(() => {
+                      /* surfaced via the hook's error state */
+                    })
+                  }
+                >
+                  {keysLoading ? (
+                    <CircularProgress size={16} sx={{ color: "white" }} />
+                  ) : (
+                    "Register key"
+                  )}
+                </Button>
+              }
+            >
+              Register your encryption key to receive full invoice details.
+              Until you do, senders can only record invoices on-chain.
+            </Alert>
+          )}
+
+          {/* Registered on-chain, but this tab holds no private key — the key
+              is derived from a signature and never stored beyond the session,
+              so nothing can be decrypted until the user re-derives it. */}
+          {isConnected && !isUnsupportedNetwork && isRegistered && !keys && (
+            <Alert
+              severity="warning"
+              sx={{ mb: 2 }}
+              action={
+                <Button
+                  size="small"
+                  variant="contained"
+                  disabled={keysLoading}
+                  onClick={() =>
+                    deriveKeysOnly(true).catch(() => {
+                      /* surfaced via the hook's error state */
+                    })
+                  }
+                >
+                  {keysLoading ? (
+                    <CircularProgress size={16} sx={{ color: "white" }} />
+                  ) : (
+                    "Unlock inbox"
+                  )}
+                </Button>
+              }
+            >
+              Sign to unlock your inbox. Incoming invoice details stay encrypted
+              until you do — this signature is free and costs no gas.
+            </Alert>
+          )}
+
+          {isConnected && keysError && (
+            <Alert severity="error" sx={{ mb: 2 }}>
+              {keysError}
+            </Alert>
+          )}
 
           {/* UNIFORM ERROR DISPLAY */}
           <Snackbar
@@ -1415,6 +1650,36 @@ function ReceivedInvoice() {
                                   icon={<UnpaidIcon />}
                                 />
                               )}
+                              {invoice._onChainOnly && (
+                                <Tooltip
+                                  title={
+                                    invoice._hashMismatch
+                                      ? "The details delivered for this invoice do not match the hash the sender recorded on-chain, so they are not shown. Only the on-chain amount and addresses can be trusted."
+                                      : "Full details have not arrived yet. The amount and addresses shown come from the blockchain."
+                                  }
+                                >
+                                  <Chip
+                                    icon={
+                                      invoice._hashMismatch ? (
+                                        <ErrorIcon />
+                                      ) : (
+                                        <WarningIcon />
+                                      )
+                                    }
+                                    label={
+                                      invoice._hashMismatch
+                                        ? "Unverified"
+                                        : "Details pending"
+                                    }
+                                    color={
+                                      invoice._hashMismatch ? "error" : "default"
+                                    }
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{ mt: 0.5 }}
+                                  />
+                                </Tooltip>
+                              )}
                             </TableCell>
                             <TableCell>
                               <span className="text-sm text-gray-600">
@@ -1795,15 +2060,11 @@ function ReceivedInvoice() {
                   <div className="flex justify-between text-sm text-gray-500 mb-2">
                     <span>
                       Issued:{" "}
-                      {new Date(
-                        drawerState.selectedInvoice.issueDate
-                      ).toLocaleDateString()}
+                      {formatInvoiceDate(drawerState.selectedInvoice.issueDate)}
                     </span>
                     <span>
                       Due:{" "}
-                      {new Date(
-                        drawerState.selectedInvoice.dueDate
-                      ).toLocaleDateString()}
+                      {formatInvoiceDate(drawerState.selectedInvoice.dueDate)}
                     </span>
                   </div>
                 </div>

--- a/frontend/src/page/SentInvoice.jsx
+++ b/frontend/src/page/SentInvoice.jsx
@@ -15,16 +15,21 @@ import SwipeableDrawer from "@mui/material/SwipeableDrawer";
 import { generateInvoicePDF } from "@/utils/generateInvoicePDF";
 import { formatInvoiceTotal } from "@/utils/invoiceExportHelpers";
 import { useInvoiceExport } from "@/hooks/useInvoiceExport";
-import { getSentInvoices as getLocalSentInvoices, storeInvoice, updateInvoiceStatus } from "../services/invoiceStorage/invoiceDB.js";
+import { getSentInvoices as getLocalSentInvoices, getInvoiceById, updateInvoiceStatus } from "../services/invoiceStorage/invoiceDB.js";
+import { verifyInvoiceHash } from "@/services/relay/invoiceHashUtils.js";
+import { sendEncryptedInvoice } from "@/services/relay/relayInvoiceMessaging.js";
+import { fetchPublicKeyFromChain } from "@/services/relay/relayKeyManager.js";
 
 import { ERC20_ABI } from "@/contractsABI/ERC20_ABI";
 import toast from "react-hot-toast";
+import { resolveInvoiceDecimals, formatInvoiceDate } from "@/utils/invoiceAmounts";
 import {
   Skeleton,
   Chip,
   Avatar,
   Tooltip,
   IconButton,
+  CircularProgress,
   Dialog,
   DialogTitle,
   DialogContent,
@@ -45,6 +50,9 @@ import TableChartIcon from "@mui/icons-material/TableChart";
 import DataObjectIcon from "@mui/icons-material/DataObject";
 import PictureAsPdfIcon from "@mui/icons-material/PictureAsPdf";
 import CancelIcon from "@mui/icons-material/Cancel";
+import SendIcon from "@mui/icons-material/Send";
+import ErrorIcon from "@mui/icons-material/Error";
+import WarningIcon from "@mui/icons-material/Warning";
 import CurrencyExchangeIcon from "@mui/icons-material/CurrencyExchange";
 import { useTokenList } from "@/hooks/useTokenList";
 import WalletConnectionAlert from "@/components/WalletConnectionAlert";
@@ -57,6 +65,8 @@ const columns = [
   { id: "date", label: "Date", minWidth: 100 },
   { id: "actions", label: "Actions", minWidth: 150 },
 ];
+
+
 
 function SentInvoice() {
   const [page, setPage] = useState(0);
@@ -74,6 +84,8 @@ function SentInvoice() {
   const [cancelConfirmOpen, setCancelConfirmOpen] = useState(false);
   const [invoiceToCancel, setInvoiceToCancel] = useState(null);
   const [showWalletAlert, setShowWalletAlert] = useState(!isConnected);
+  const [refreshTrigger, setRefreshTrigger] = useState(0);
+  const [resending, setResending] = useState({});
 
   // Get tokens from the hook
   const { tokens } = useTokenList(chainId || 1);
@@ -172,10 +184,7 @@ function SentInvoice() {
             const to = invoice[2].toLowerCase();
             const isPaid = invoice[5];
             const isCancelled = invoice[6];
-            const encryptedStringBase64 = invoice[7];
-            const dataToEncryptHash = invoice[8];
-
-            if (!encryptedStringBase64 || !dataToEncryptHash) continue;
+            const invoiceDataHash = invoice[7];
 
             const currentUserAddress = address.toLowerCase();
             if (currentUserAddress !== from && currentUserAddress !== to) {
@@ -186,36 +195,40 @@ function SentInvoice() {
             const localInv = localInvoiceMap.get(id);
             let parsed;
 
-            if (localInv && localInv.data) {
+            // As the sender, the payload only ever existed on this device.
+            // Check it still matches the on-chain commitment before trusting it.
+            const payloadTrusted =
+              localInv?.data && verifyInvoiceHash(localInv.data, invoiceDataHash);
+
+            if (payloadTrusted) {
               parsed = { ...localInv.data };
-              
+
               // Update local status if it changed
               if (localInv.isPaid !== isPaid || localInv.isCancelled !== isCancelled) {
                 await updateInvoiceStatus(chainId, id, { isPaid, isCancelled });
               }
             } else {
-              if (!encryptedStringBase64) continue;
-              const decryptedString = atob(encryptedStringBase64);
-              parsed = JSON.parse(decryptedString);
-
-              // Cache it locally
-              try {
-                await storeInvoice({
-                  invoiceId: id,
-                  chainId,
-                  from,
-                  to,
-                  isPaid,
-                  isCancelled,
-                  wakuDelivered: false,
-                  invoiceDataHash: dataToEncryptHash,
-                  data: parsed
-                });
-              } catch (err) {
-                console.warn(`Failed to cache invoice ${id} locally`, err);
+              if (localInv?.data) {
+                console.warn(
+                  `Invoice ${id}: stored payload does not match the on-chain hash; showing on-chain data only`
+                );
               }
+              // Local storage was cleared, or this invoice was created on
+              // another device. The details are unrecoverable — the chain only
+              // holds the hash — so show what the chain does know.
+              parsed = {
+                amountDue: invoice[3].toString(),
+                user: { address: from },
+                client: { address: to },
+                paymentToken: { address: invoice[4] },
+                issueDate: null,
+                dueDate: null,
+                _onChainOnly: true,
+                _hashMismatch: Boolean(localInv?.data),
+              };
             }
 
+            parsed["relayDelivered"] = localInv?.relayDelivered ?? false;
             parsed["id"] = BigInt(id);
             parsed["isPaid"] = isPaid;
             parsed["isCancelled"] = isCancelled;
@@ -271,6 +284,21 @@ function SentInvoice() {
               }
             }
 
+            // On-chain amounts are raw token units; the stored payload carries
+            // an already-formatted decimal string, so only stubs need scaling.
+            if (parsed._onChainOnly) {
+              const decimals = resolveInvoiceDecimals(parsed.paymentToken);
+              if (decimals === null) {
+                // Showing a base-unit figure as if it were a token amount, or
+                // feeding it to parseUnits, is worse than omitting the invoice.
+                console.warn(
+                  `Invoice ${parsed.id}: cannot resolve token decimals, skipping`
+                );
+                continue;
+              }
+              parsed.amountDue = ethers.formatUnits(parsed.amountDue, decimals);
+            }
+
             decryptedInvoices.push(parsed);
           } catch (err) {
             console.error(`Error processing invoice ${invoice[0]}:`, err);
@@ -294,7 +322,89 @@ function SentInvoice() {
 
     fetchSentInvoices();
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [walletClient, address, tokens, chainId]); // Added tokens and chainId to dependency array
+  }, [walletClient, address, tokens, chainId, refreshTrigger]); // Added tokens and chainId to dependency array
+
+  /**
+   * Re-deliver an invoice's encrypted payload to its recipient.
+   *
+   * Waku retained messages on the network, so a client could always catch up.
+   * The relay only holds what was successfully posted, so a send that failed —
+   * or a recipient who registered their key after the invoice was created —
+   * needs an explicit retry from the one device that still holds the payload.
+   */
+  const handleResend = async (invoice) => {
+    const invoiceId = invoice.id.toString();
+    if (invoice._onChainOnly) {
+      toast.error("This invoice's details are not available on this device.");
+      return;
+    }
+
+    if (!walletClient) {
+      // Otherwise BrowserProvider throws and the catch below blames the relay.
+      toast.error("Connect your wallet to resend this invoice.");
+      return;
+    }
+
+    setResending((prev) => ({ ...prev, [invoiceId]: true }));
+    try {
+      const local = await getInvoiceById(chainId, invoiceId);
+      if (!local?.data) {
+        toast.error("This invoice's details are not available on this device.");
+        return;
+      }
+
+      const provider = new BrowserProvider(walletClient);
+      const signer = await provider.getSigner();
+      const contractAddress = import.meta.env[`VITE_CONTRACT_ADDRESS_${chainId}`];
+      if (!contractAddress) {
+        // Otherwise the Contract constructor throws and the catch below blames
+        // the relay for what is actually an unsupported network.
+        toast.error("Chainvoice is not deployed on this network.");
+        return;
+      }
+      const contract = new Contract(contractAddress, ChainvoiceABI, signer);
+
+      const clientAddress = local.to;
+      const receiverPublicKey = await fetchPublicKeyFromChain(contract, clientAddress);
+      if (!receiverPublicKey) {
+        toast.error(
+          "Your client has not registered an encryption key yet. Ask them to register, then resend."
+        );
+        return;
+      }
+
+      await sendEncryptedInvoice({
+        invoiceData: local.data,
+        receiverPublicKey,
+        receiverAddress: clientAddress,
+        senderAddress: address,
+        chainId,
+        invoiceId,
+      });
+
+      await updateInvoiceStatus(chainId, invoiceId, { relayDelivered: true });
+      toast.success("Invoice details sent to your client.");
+      setRefreshTrigger((p) => p + 1);
+    } catch (err) {
+      console.error(`Failed to resend invoice ${invoiceId}:`, err);
+      // Not every failure here is the relay's. A rejected wallet connection and
+      // a malformed registry key both reach this block, and blaming the relay
+      // for either sends the user looking in the wrong place.
+      const message =
+        typeof err?.message === 'string' ? err.message : String(err ?? '');
+      if (err?.code === 'ACTION_REJECTED' || err?.code === 4001) {
+        toast("Cancelled in your wallet.", { icon: "✋" });
+      } else if (/malformed public key/i.test(message)) {
+        toast.error(
+          "Your client's registered encryption key is invalid. Ask them to register again."
+        );
+      } else {
+        toast.error("Could not reach the relay. Please try again.");
+      }
+    } finally {
+      setResending((prev) => ({ ...prev, [invoiceId]: false }));
+    }
+  };
 
   const [drawerState, setDrawerState] = useState({
     open: false,
@@ -383,10 +493,7 @@ function SentInvoice() {
     )}`;
   };
 
-  const formatDate = (issueDate) => {
-    const date = new Date(issueDate);
-    return date.toLocaleString();
-  };
+  const formatDate = formatInvoiceDate;
 
   return (
     <>
@@ -574,6 +681,36 @@ function SentInvoice() {
                                   variant="outlined"
                                 />
                               )}
+                              {invoice._onChainOnly && (
+                                <Tooltip
+                                  title={
+                                    invoice._hashMismatch
+                                      ? "The details stored on this device do not match the hash recorded on-chain for this invoice."
+                                      : "This invoice's details are not on this device. Only the chain's record of it is shown."
+                                  }
+                                >
+                                  <Chip
+                                    icon={
+                                      invoice._hashMismatch ? (
+                                        <ErrorIcon />
+                                      ) : (
+                                        <WarningIcon />
+                                      )
+                                    }
+                                    label={
+                                      invoice._hashMismatch
+                                        ? "Unverified"
+                                        : "Details unavailable"
+                                    }
+                                    color={
+                                      invoice._hashMismatch ? "error" : "default"
+                                    }
+                                    size="small"
+                                    variant="outlined"
+                                    sx={{ mt: 0.5 }}
+                                  />
+                                </Tooltip>
+                              )}
                             </TableCell>
 
                             {/* Date Column */}
@@ -607,6 +744,53 @@ function SentInvoice() {
                                     </IconButton>
                                   </Tooltip>
                                 )}
+                                {/* Always offered whenever the payload is on
+                                    this device. A delivered invoice can still
+                                    need resending: the client may have cleared
+                                    their storage, or the relay may have dropped
+                                    the message before they polled for it. */}
+                                {!invoice._onChainOnly && (
+                                    <Tooltip
+                                      title={
+                                        invoice.relayDelivered
+                                          ? "Send the details to your client again"
+                                          : "Client has not received the details — resend"
+                                      }
+                                    >
+                                      <span>
+                                        <IconButton
+                                          size="small"
+                                          disabled={Boolean(
+                                            resending[invoice.id.toString()]
+                                          )}
+                                          onClick={() => handleResend(invoice)}
+                                          sx={{
+                                            backgroundColor: invoice.relayDelivered
+                                              ? "#f1f5f9"
+                                              : "#fef3c7",
+                                            "&:hover": {
+                                              backgroundColor: invoice.relayDelivered
+                                                ? "#e2e8f0"
+                                                : "#fde68a",
+                                            },
+                                          }}
+                                        >
+                                          {resending[invoice.id.toString()] ? (
+                                            <CircularProgress size={16} />
+                                          ) : (
+                                            <SendIcon
+                                              fontSize="small"
+                                              sx={{
+                                                color: invoice.relayDelivered
+                                                  ? "#475569"
+                                                  : "#b45309",
+                                              }}
+                                            />
+                                          )}
+                                        </IconButton>
+                                      </span>
+                                    </Tooltip>
+                                  )}
                                 <Tooltip title="View Details">
                                   <IconButton
                                     size="small"
@@ -889,15 +1073,11 @@ function SentInvoice() {
                 <div className="flex justify-between text-sm text-gray-500 mb-2">
                   <span>
                     Issued:{" "}
-                    {new Date(
-                      drawerState.selectedInvoice.issueDate
-                    ).toLocaleDateString()}
+                    {formatInvoiceDate(drawerState.selectedInvoice.issueDate)}
                   </span>
                   <span>
                     Due:{" "}
-                    {new Date(
-                      drawerState.selectedInvoice.dueDate
-                    ).toLocaleDateString()}
+                    {formatInvoiceDate(drawerState.selectedInvoice.dueDate)}
                   </span>
                 </div>
               </div>

--- a/frontend/src/services/relay/index.js
+++ b/frontend/src/services/relay/index.js
@@ -1,0 +1,30 @@
+export {
+  getRelayClient,
+  resetRelayClient,
+  isRelayHealthy,
+  RELAY_PROXY_PATH,
+} from './relayClient.js';
+export {
+  deriveRelayKeyPair,
+  registerPublicKeyOnChain,
+  fetchPublicKeyFromChain,
+  clearCachedKeys,
+  hasCachedKeys,
+  getCachedKeyPair,
+  hexToBytes,
+  bytesToHex,
+  DERIVATION_MESSAGE,
+} from './relayKeyManager.js';
+export {
+  encryptPayload,
+  decryptPayload,
+  tryDecryptPayload,
+} from './invoiceCrypto.js';
+export {
+  sendEncryptedInvoice,
+  fetchInvoiceMessages,
+  pollInvoiceMessages,
+  toMailboxAddress,
+  DEFAULT_POLL_INTERVAL_MS,
+} from './relayInvoiceMessaging.js';
+export { computeInvoiceHash, verifyInvoiceHash, stableStringify } from './invoiceHashUtils.js';

--- a/frontend/src/services/relay/invoiceCrypto.js
+++ b/frontend/src/services/relay/invoiceCrypto.js
@@ -1,0 +1,88 @@
+import { encrypt, decrypt } from 'eciesjs';
+
+/**
+ * End-to-end encryption for invoice payloads.
+ *
+ * The relay is a dumb mailbox: it stores an opaque base64 blob and never
+ * sees plaintext. Confidentiality comes entirely from this module.
+ *
+ * Scheme: ECIES over secp256k1 (ephemeral ECDH -> HKDF-SHA256 -> AES-256-GCM),
+ * the same primitive and the same 65-byte uncompressed public keys used by
+ * the on-chain key registry, so registered keys keep working unchanged.
+ */
+
+/** Encode bytes as base64 without blowing the stack on large payloads. */
+function bytesToBase64(bytes) {
+  const CHUNK = 0x8000;
+  let binary = '';
+  for (let i = 0; i < bytes.length; i += CHUNK) {
+    binary += String.fromCharCode.apply(
+      null,
+      bytes.subarray(i, i + CHUNK)
+    );
+  }
+  return btoa(binary);
+}
+
+/** Decode a base64 string back into bytes. */
+function base64ToBytes(base64) {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i++) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}
+
+/**
+ * Encrypt a JSON-serialisable value for a recipient's public key.
+ *
+ * @param {Uint8Array|string} publicKey - recipient's secp256k1 public key
+ *   (65-byte uncompressed bytes, or 0x-prefixed hex)
+ * @param {*} value - any JSON-serialisable value; bigints are stringified
+ * @returns {string} base64 ciphertext, ready to hand to the relay
+ */
+export function encryptPayload(publicKey, value) {
+  const json = JSON.stringify(value, (_, v) =>
+    typeof v === 'bigint' ? v.toString() : v
+  );
+  const ciphertext = encrypt(publicKey, new TextEncoder().encode(json));
+  return bytesToBase64(ciphertext);
+}
+
+/**
+ * Decrypt a base64 ciphertext produced by {@link encryptPayload}.
+ *
+ * Throws if the payload was not encrypted for this key — callers polling a
+ * public mailbox should treat a throw as "not for me" and move on.
+ *
+ * @param {Uint8Array|string} privateKey - recipient's 32-byte private key
+ * @param {string} base64Ciphertext
+ * @returns {*} the decrypted value
+ */
+export function decryptPayload(privateKey, base64Ciphertext) {
+  const plaintext = decrypt(privateKey, base64ToBytes(base64Ciphertext));
+  return JSON.parse(new TextDecoder().decode(plaintext));
+}
+
+/**
+ * Attempt decryption, returning null instead of throwing.
+ *
+ * The relay mailbox is world-readable and world-writable, so a polling
+ * client routinely encounters messages it cannot decrypt: junk from other
+ * senders, or invoices encrypted to a key the user has since rotated.
+ * Those are normal, not errors.
+ *
+ * @param {Uint8Array|string} privateKey
+ * @param {string} base64Ciphertext
+ * @returns {*|null}
+ */
+export function tryDecryptPayload(privateKey, base64Ciphertext) {
+  try {
+    return decryptPayload(privateKey, base64Ciphertext);
+  } catch {
+    return null;
+  }
+}
+
+export { bytesToBase64, base64ToBytes };

--- a/frontend/src/services/relay/invoiceHashUtils.js
+++ b/frontend/src/services/relay/invoiceHashUtils.js
@@ -1,0 +1,68 @@
+import { ethers } from 'ethers';
+
+/**
+ * Compute a deterministic keccak256 hash of invoice data.
+ * Keys are sorted recursively to ensure the same data always
+ * produces the same hash regardless of property insertion order.
+ *
+ * This is the commitment stored on-chain as `invoiceDataHash`. The
+ * plaintext never touches the chain — the receiver recomputes this hash
+ * from the payload delivered over the relay and compares it against the
+ * on-chain value to prove the sender did not tamper with it in transit.
+ *
+ * @param {Object} invoiceData - the invoice data object
+ * @returns {string} - keccak256 hash as hex string (0x-prefixed)
+ */
+export function computeInvoiceHash(invoiceData) {
+  const serialized = stableStringify(invoiceData);
+  return ethers.keccak256(ethers.toUtf8Bytes(serialized));
+}
+
+/**
+ * Verify that an invoice's data matches an expected hash.
+ *
+ * @param {Object} invoiceData - the invoice data object
+ * @param {string} expectedHash - the expected hash (from on-chain)
+ * @returns {boolean}
+ */
+export function verifyInvoiceHash(invoiceData, expectedHash) {
+  if (!expectedHash) return false;
+  const computed = computeInvoiceHash(invoiceData);
+  return computed.toLowerCase() === expectedHash.toLowerCase();
+}
+
+/**
+ * Deterministic JSON serialization with sorted keys (recursive).
+ * Ensures the same object always produces the same string
+ * regardless of key insertion order.
+ *
+ * @param {*} obj
+ * @returns {string}
+ */
+export function stableStringify(obj) {
+  // `null` for undefined, matching what JSON.stringify does to an undefined
+  // array entry. The payload reaches the receiver as JSON, so anything this
+  // renders differently to JSON.stringify makes the two sides compute
+  // different hashes and silently fails verification.
+  if (obj === null || obj === undefined) return 'null';
+  if (typeof obj === 'bigint') return JSON.stringify(obj.toString());
+  if (obj instanceof Date) return JSON.stringify(obj.toISOString());
+  if (typeof obj !== 'object') return JSON.stringify(obj);
+  if (Array.isArray(obj)) {
+    // Indexed rather than mapped: Array.prototype.map skips holes, which would
+    // collapse a sparse array into fewer elements than JSON.stringify emits.
+    const items = [];
+    for (let i = 0; i < obj.length; i++) {
+      items.push(stableStringify(obj[i]));
+    }
+    return '[' + items.join(',') + ']';
+  }
+  const sortedKeys = Object.keys(obj).sort();
+  const parts = [];
+  for (const key of sortedKeys) {
+    if (obj[key] !== undefined) {
+      parts.push(JSON.stringify(key) + ':' + stableStringify(obj[key]));
+    }
+  }
+  return '{' + parts.join(',') + '}';
+}

--- a/frontend/src/services/relay/relayClient.js
+++ b/frontend/src/services/relay/relayClient.js
@@ -1,0 +1,91 @@
+import { RelayClient } from '@aossie-org/thrubox-client';
+
+/** Path the Vite dev server proxies to the relay. Keep in sync with vite.config.js. */
+export const RELAY_PROXY_PATH = '/relay';
+
+const DEFAULT_RELAY_URL = 'http://localhost:3000';
+const DEFAULT_TIMEOUT_MS = 15_000;
+const RETRIES = 3;
+
+let client = null;
+
+/**
+ * Request timeout, overridable via VITE_RELAY_TIMEOUT_MS.
+ *
+ * Worth raising on hosts that suspend idle instances: a cold start can take
+ * the better part of a minute, and the SDK deliberately does not retry POSTs
+ * (a retried send would duplicate the message), so one timed-out request is
+ * one invoice that failed to reach its recipient.
+ */
+function resolveTimeout() {
+  const raw = Number(import.meta.env.VITE_RELAY_TIMEOUT_MS);
+  return Number.isFinite(raw) && raw > 0 ? raw : DEFAULT_TIMEOUT_MS;
+}
+
+/**
+ * Work out which URL the browser should talk to.
+ *
+ * The relay serves no CORS headers, so a direct cross-origin request from the
+ * browser fails its preflight. There are two ways around that, and both are
+ * supported here:
+ *
+ * - Proxy it, so the browser never makes a cross-origin request at all. In
+ *   development the Vite dev server does this at /relay. In production, set
+ *   VITE_RELAY_URL to a path rather than a URL (e.g. "/relay") and let the
+ *   host rewrite it — Vercel `rewrites`, Netlify `redirects`, nginx
+ *   `proxy_pass`. No CORS needed.
+ * - Address the relay directly with an absolute VITE_RELAY_URL, which
+ *   requires the relay to serve CORS headers for your origin.
+ *
+ * @returns {string} absolute base URL for RelayClient
+ */
+function resolveBaseUrl() {
+  const configured = (import.meta.env.VITE_RELAY_URL || '').trim();
+
+  if (typeof window !== 'undefined') {
+    if (import.meta.env.DEV) {
+      return `${window.location.origin}${RELAY_PROXY_PATH}`;
+    }
+    // A path rather than a URL means "same origin, the host proxies it".
+    if (configured.startsWith('/')) {
+      return `${window.location.origin}${configured.replace(/\/+$/, '')}`;
+    }
+  }
+
+  return configured || DEFAULT_RELAY_URL;
+}
+
+/**
+ * Get the shared RelayClient instance, creating it on first use.
+ * @returns {RelayClient}
+ */
+export function getRelayClient() {
+  if (!client) {
+    const apiKey = (import.meta.env.VITE_RELAY_API_KEY || '').trim();
+    client = new RelayClient(resolveBaseUrl(), {
+      ...(apiKey ? { apiKey } : {}),
+      timeout: resolveTimeout(),
+      retries: RETRIES,
+    });
+  }
+  return client;
+}
+
+/** Drop the cached client. Only useful in tests. */
+export function resetRelayClient() {
+  client = null;
+}
+
+/**
+ * Check whether the relay is reachable.
+ * @returns {Promise<boolean>}
+ */
+export async function isRelayHealthy() {
+  try {
+    const health = await getRelayClient().health();
+    return health?.status === 'ok';
+  } catch (err) {
+    console.warn('[RelayClient] Health check failed:', err);
+    return false;
+  }
+}

--- a/frontend/src/services/relay/relayInvoiceMessaging.js
+++ b/frontend/src/services/relay/relayInvoiceMessaging.js
@@ -1,0 +1,223 @@
+import { getRelayClient } from './relayClient.js';
+import { encryptPayload, tryDecryptPayload } from './invoiceCrypto.js';
+
+const DEFAULT_POLL_INTERVAL_MS = 15_000;
+const ENVELOPE_TYPE = 'invoice';
+
+/**
+ * Normalise an address for relay addressing.
+ *
+ * The relay looks messages up by exact string match, so a message sent to a
+ * checksummed address is invisible to a client polling the lowercase form.
+ * Every address crossing the relay boundary goes through here.
+ *
+ * @param {string} address
+ * @returns {string}
+ */
+export function toMailboxAddress(address) {
+  if (!address) throw new Error('Relay address is required');
+  return address.toLowerCase();
+}
+
+/**
+ * Build the envelope that gets encrypted and handed to the relay.
+ *
+ * @param {Object} invoiceData - plaintext invoice payload
+ * @param {number|string} chainId
+ * @param {number|string} invoiceId
+ * @returns {Object}
+ */
+function buildEnvelope(invoiceData, chainId, invoiceId) {
+  // Fail loudly here rather than shipping a broken envelope. A non-numeric
+  // chainId becomes NaN, JSON-serialises to null, and never matches the
+  // receiver's `Number(envelope.chainId) !== Number(chainId)` check — the
+  // message would be encrypted, accepted by the relay, and silently ignored
+  // forever, with the sender told it succeeded.
+  // Positive check rather than just finite: Number(null) and Number('') are
+  // both 0, which is finite but not a real chain.
+  const numericChainId = Number(chainId);
+  if (!Number.isFinite(numericChainId) || numericChainId <= 0) {
+    throw new Error(`Invalid chainId for relay envelope: ${chainId}`);
+  }
+  if (invoiceId === null || invoiceId === undefined || invoiceId === '') {
+    throw new Error('Invalid invoiceId for relay envelope');
+  }
+
+  return {
+    type: ENVELOPE_TYPE,
+    invoiceId: invoiceId.toString(),
+    chainId: numericChainId,
+    timestamp: Date.now(),
+    data: invoiceData,
+  };
+}
+
+/**
+ * Encrypt an invoice for its recipient and post it to the relay.
+ *
+ * `invoiceData` must be exactly the object that was hashed into the
+ * on-chain `invoiceDataHash`. The receiver recomputes the hash over what
+ * arrives here and rejects it on mismatch, so any field added, dropped or
+ * reordered on the way in will fail verification on the way out.
+ *
+ * @param {Object} params
+ * @param {Object} params.invoiceData - plaintext invoice payload (as hashed)
+ * @param {Uint8Array|string} params.receiverPublicKey - from the on-chain registry
+ * @param {string} params.receiverAddress - recipient wallet address
+ * @param {string} params.senderAddress - sender wallet address
+ * @param {number|string} params.chainId
+ * @param {number|string} params.invoiceId - on-chain invoice ID
+ * @returns {Promise<import('@aossie-org/thrubox-client').Message>}
+ */
+export async function sendEncryptedInvoice({
+  invoiceData,
+  receiverPublicKey,
+  receiverAddress,
+  senderAddress,
+  chainId,
+  invoiceId,
+}) {
+  if (!receiverPublicKey) {
+    throw new Error('Recipient has not registered a public key');
+  }
+
+  const envelope = buildEnvelope(invoiceData, chainId, invoiceId);
+  const payload = encryptPayload(receiverPublicKey, envelope);
+
+  return getRelayClient().send({
+    to: toMailboxAddress(receiverAddress),
+    from: toMailboxAddress(senderAddress),
+    payload,
+  });
+}
+
+/**
+ * Decrypt the relay messages that belong to this user on this chain.
+ *
+ * Undecryptable messages are skipped: the mailbox is public, so anyone can
+ * drop anything into it, and that is expected rather than exceptional.
+ *
+ * Nothing returned here is authenticated. The relay does not verify who
+ * posted a message, and the envelope carries no sender signature — decrypting
+ * successfully only proves the sender knew the recipient's public key, which
+ * is published on-chain. Anyone can therefore deliver a well-formed envelope
+ * claiming any sender and any contents.
+ *
+ * Callers must treat `claimedFrom` and `envelope.data` as untrusted until
+ * `envelope.data` has been checked against the on-chain `invoiceDataHash` for
+ * `envelope.invoiceId` (see verifyInvoiceHash). That check is what makes the
+ * payload trustworthy, and it needs a chain read this module does not perform.
+ *
+ * @param {Array} messages - raw relay messages
+ * @param {Uint8Array|string} privateKey
+ * @param {number|string} chainId
+ * @returns {Array<{messageId: string, claimedFrom: string, envelope: Object}>}
+ */
+function decodeMessages(messages, privateKey, chainId) {
+  const decoded = [];
+  for (const message of messages) {
+    if (!message?.payload) continue;
+
+    const envelope = tryDecryptPayload(privateKey, message.payload);
+    if (!envelope) continue;
+
+    if (envelope.type !== ENVELOPE_TYPE) continue;
+    if (Number(envelope.chainId) !== Number(chainId)) continue;
+    if (!envelope.invoiceId || !envelope.data) continue;
+
+    decoded.push({
+      messageId: message.id,
+      // Relay metadata, set by whoever posted the message. Unverified.
+      claimedFrom: message.from,
+      envelope,
+    });
+  }
+  return decoded;
+}
+
+/**
+ * Fetch and decrypt every invoice currently waiting in the user's mailbox.
+ *
+ * Replaces the Waku Store query: the relay retains messages for its
+ * configured TTL, so this is how a client catches up after being offline.
+ *
+ * @param {Object} params
+ * @param {Uint8Array|string} params.privateKey
+ * @param {string} params.address - the user's wallet address
+ * @param {number|string} params.chainId
+ * @returns {Promise<Array<{messageId: string, claimedFrom: string, envelope: Object}>>}
+ */
+export async function fetchInvoiceMessages({ privateKey, address, chainId }) {
+  const messages = await getRelayClient().receive(toMailboxAddress(address));
+  return decodeMessages(messages, privateKey, chainId);
+}
+
+/**
+ * Poll the relay for new invoices.
+ *
+ * The relay has no cursor — every poll returns the full mailbox — so this
+ * tracks the message IDs it has already surfaced and only invokes
+ * `onInvoice` for ones it has not seen. Messages are deliberately left on
+ * the relay until they expire, so a second device can still pick them up.
+ *
+ * @param {Object} params
+ * @param {Uint8Array|string} params.privateKey
+ * @param {string} params.address - the user's wallet address
+ * @param {number|string} params.chainId
+ * @param {(item: {messageId: string, claimedFrom: string, envelope: Object}) => void|Promise<void>} params.onInvoice
+ * @param {(error: Error) => void} [params.onError]
+ * @param {number} [params.intervalMs]
+ * @param {Iterable<string>} [params.knownMessageIds] - IDs to treat as already seen
+ * @returns {() => void} stop function
+ */
+export function pollInvoiceMessages({
+  privateKey,
+  address,
+  chainId,
+  onInvoice,
+  onError,
+  intervalMs = DEFAULT_POLL_INTERVAL_MS,
+  knownMessageIds = [],
+}) {
+  const seen = new Set(knownMessageIds);
+  let stopped = false;
+
+  const stopPolling = getRelayClient().poll(
+    toMailboxAddress(address),
+    async (messages) => {
+      if (stopped) return;
+      for (const item of decodeMessages(messages, privateKey, chainId)) {
+        if (stopped) return;
+        if (seen.has(item.messageId)) continue;
+
+        // Claim before awaiting, release if the handler fails. The SDK does
+        // not await this callback before scheduling the next poll, so two
+        // polls can overlap: claiming up front stops both from processing the
+        // same message, and releasing on failure stops a transient error —
+        // a failed IndexedDB write, say — from burying the invoice for good.
+        seen.add(item.messageId);
+        try {
+          await onInvoice(item);
+        } catch (err) {
+          seen.delete(item.messageId);
+          console.warn('[RelayInvoiceMessaging] onInvoice handler failed, will retry:', err);
+        }
+      }
+    },
+    {
+      intervalMs,
+      onError: (err) => {
+        if (stopped) return;
+        if (onError) onError(err);
+        else console.warn('[RelayInvoiceMessaging] Poll failed:', err);
+      },
+    }
+  );
+
+  return () => {
+    stopped = true;
+    stopPolling();
+  };
+}
+
+export { DEFAULT_POLL_INTERVAL_MS };

--- a/frontend/src/services/relay/relayKeyManager.js
+++ b/frontend/src/services/relay/relayKeyManager.js
@@ -1,0 +1,313 @@
+import { ethers } from 'ethers';
+
+/**
+ * Message the user signs to derive their messaging keypair.
+ *
+ * Do not change this string. The derived public key is what users have
+ * already registered in the on-chain registry; a different message derives
+ * a different key, silently breaking decryption for everyone who registered
+ * before the change. It is named after Waku for historical reasons only —
+ * the derivation itself is transport-independent.
+ */
+const DERIVATION_MESSAGE = 'ChainVoice Waku Key Derivation v1';
+const KEY_STORAGE_PREFIX = 'chainvoice_relay_keys_';
+
+/** secp256k1 key sizes, as the on-chain registry validates them. */
+const PRIVATE_KEY_BYTES = 32;
+const PUBLIC_KEY_BYTES = 65;
+const UNCOMPRESSED_PREFIX = 0x04;
+
+/** In-memory cache for derived keys (keyed by lowercase address). */
+const memoryCache = new Map();
+
+/**
+ * Derivations currently awaiting a signature, keyed by lowercase address.
+ *
+ * The cache is only populated once signMessage resolves, so two callers racing
+ * before that both miss it and both open a wallet prompt. Sharing the in-flight
+ * promise means the second caller waits on the first signature instead.
+ */
+const inFlightDerivations = new Map();
+
+/**
+ * Bumped whenever an address is cleared. A derivation captures the value it
+ * started with and refuses to write its result if it no longer matches, so a
+ * signature still pending at the moment of a disconnect cannot restore the key
+ * afterwards.
+ */
+const cacheGenerations = new Map();
+
+function currentGeneration(cacheKey) {
+  return cacheGenerations.get(cacheKey) ?? 0;
+}
+
+/**
+ * Convert hex string to Uint8Array.
+ * @param {string} hex
+ * @returns {Uint8Array}
+ */
+function hexToBytes(hex) {
+  const cleanHex = hex.startsWith('0x') ? hex.slice(2) : hex;
+  if (cleanHex.length % 2 !== 0) throw new Error('Invalid hex string: odd length');
+  if (!/^[0-9a-fA-F]*$/.test(cleanHex)) throw new Error('Invalid hex string: non-hex characters');
+  const bytes = new Uint8Array(cleanHex.length / 2);
+  for (let i = 0; i < cleanHex.length; i += 2) {
+    bytes[i / 2] = parseInt(cleanHex.slice(i, i + 2), 16);
+  }
+  return bytes;
+}
+
+/**
+ * Convert Uint8Array to hex string (0x-prefixed).
+ * @param {Uint8Array} bytes
+ * @returns {string}
+ */
+function bytesToHex(bytes) {
+  return '0x' + Array.from(bytes).map((b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+/**
+ * Derive an ECIES keypair from a wallet signature.
+ *
+ * The user signs a deterministic message, and we use keccak256 of the
+ * signature as the 32-byte private key for secp256k1. This ensures the
+ * same wallet always derives the same key pair, so the key never has to
+ * be stored anywhere durable.
+ *
+ * @param {import('ethers').Signer} signer - ethers v6 signer
+ * @param {string} address - wallet address
+ * @param {boolean} [rememberSession=false] - if true, cache keys in sessionStorage; if false, keep in memory only
+ * @returns {Promise<{privateKey: Uint8Array, publicKey: Uint8Array}>}
+ */
+export async function deriveRelayKeyPair(signer, address, rememberSession = false) {
+  // Check in-memory cache first (avoids re-derivation within the same page session)
+  const memCached = getMemoryCachedKeys(address);
+  if (memCached) return memCached;
+
+  // Then check sessionStorage
+  const sessionCached = getSessionCachedKeys(address);
+  if (sessionCached) {
+    // Populate memory cache so subsequent lookups are instant
+    setMemoryCachedKeys(address, sessionCached);
+    return sessionCached;
+  }
+
+  // Join an in-flight derivation for this address rather than starting a
+  // second one, so concurrent callers never produce two signature prompts.
+  const cacheKey = address.toLowerCase();
+  const pending = inFlightDerivations.get(cacheKey);
+  if (pending) return pending;
+
+  const startedAtGeneration = currentGeneration(cacheKey);
+  const derivation = (async () => {
+    // Sign deterministic message to derive keys
+    const signature = await signer.signMessage(DERIVATION_MESSAGE);
+
+    // Use keccak256 of the raw signature bytes as the private key (32 bytes)
+    const privateKeyHex = ethers.keccak256(signature);
+    const privateKey = hexToBytes(privateKeyHex);
+
+    // Derive uncompressed public key (65 bytes: 0x04 + x + y)
+    const signingKey = new ethers.SigningKey(privateKeyHex);
+    const publicKey = hexToBytes(signingKey.publicKey);
+
+    const keyPair = { privateKey, publicKey };
+
+    // The key was cleared while this signature was pending — the account was
+    // switched or disconnected. Hand the value back to whoever asked, but do
+    // not resurrect it in any cache.
+    if (currentGeneration(cacheKey) !== startedAtGeneration) {
+      return keyPair;
+    }
+
+    // Always store in memory cache
+    setMemoryCachedKeys(address, keyPair);
+
+    // Optionally persist to sessionStorage
+    if (rememberSession) {
+      cacheKeysToSession(address, privateKey, publicKey);
+    }
+
+    return keyPair;
+  })();
+
+  inFlightDerivations.set(cacheKey, derivation);
+  try {
+    return await derivation;
+  } finally {
+    inFlightDerivations.delete(cacheKey);
+  }
+}
+
+/**
+ * Store a key pair in the in-memory cache.
+ * @param {string} address
+ * @param {{privateKey: Uint8Array, publicKey: Uint8Array}} keyPair
+ */
+function setMemoryCachedKeys(address, keyPair) {
+  memoryCache.set(address.toLowerCase(), keyPair);
+}
+
+/**
+ * Retrieve a key pair from the in-memory cache.
+ * @param {string} address
+ * @returns {{privateKey: Uint8Array, publicKey: Uint8Array}|null}
+ */
+function getMemoryCachedKeys(address) {
+  return memoryCache.get(address.toLowerCase()) || null;
+}
+
+/**
+ * Cache derived keys in sessionStorage for the current session.
+ * @param {string} address
+ * @param {Uint8Array} privateKey
+ * @param {Uint8Array} publicKey
+ */
+function cacheKeysToSession(address, privateKey, publicKey) {
+  try {
+    const data = {
+      privateKey: bytesToHex(privateKey),
+      publicKey: bytesToHex(publicKey),
+    };
+    sessionStorage.setItem(
+      KEY_STORAGE_PREFIX + address.toLowerCase(),
+      JSON.stringify(data)
+    );
+  } catch (e) {
+    console.warn('[RelayKeyManager] Failed to cache keys:', e);
+  }
+}
+
+/**
+ * Retrieve cached keys from sessionStorage.
+ * @param {string} address
+ * @returns {{privateKey: Uint8Array, publicKey: Uint8Array}|null}
+ */
+function getSessionCachedKeys(address) {
+  try {
+    const raw = sessionStorage.getItem(
+      KEY_STORAGE_PREFIX + address.toLowerCase()
+    );
+    if (!raw) return null;
+    const data = JSON.parse(raw);
+    const privateKey = hexToBytes(data.privateKey);
+    const publicKey = hexToBytes(data.publicKey);
+
+    // A truncated entry still parses as valid hex, and a wrong-sized key fails
+    // every decryption silently — tryDecryptPayload swallows the error, so the
+    // inbox would just stop working with nothing in the console. Treat it as a
+    // miss and drop it so the next call re-derives.
+    if (
+      privateKey.length !== PRIVATE_KEY_BYTES ||
+      publicKey.length !== PUBLIC_KEY_BYTES ||
+      publicKey[0] !== UNCOMPRESSED_PREFIX
+    ) {
+      console.warn('[RelayKeyManager] Discarding malformed cached key');
+      sessionStorage.removeItem(KEY_STORAGE_PREFIX + address.toLowerCase());
+      return null;
+    }
+
+    return { privateKey, publicKey };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Clear cached keys for a given address from both memory and sessionStorage.
+ * @param {string} address
+ */
+export function clearCachedKeys(address) {
+  if (!address) return;
+  const key = address.toLowerCase();
+  memoryCache.delete(key);
+  inFlightDerivations.delete(key);
+  cacheGenerations.set(key, currentGeneration(key) + 1);
+  try {
+    sessionStorage.removeItem(KEY_STORAGE_PREFIX + key);
+  } catch {
+    // Ignore errors (e.g. SSR environments)
+  }
+}
+
+/**
+ * Read an already-derived key pair without ever signing.
+ *
+ * Deriving needs a wallet signature, so callers that only want to restore an
+ * existing session — a page reload, say — must not fall through to
+ * derivation: that would pop an unexplained signature prompt on load. This
+ * returns null instead when nothing is cached.
+ *
+ * @param {string} address
+ * @returns {{privateKey: Uint8Array, publicKey: Uint8Array}|null}
+ */
+export function getCachedKeyPair(address) {
+  if (!address) return null;
+
+  const memCached = getMemoryCachedKeys(address);
+  if (memCached) return memCached;
+
+  const sessionCached = getSessionCachedKeys(address);
+  if (sessionCached) {
+    // Promote to the memory cache so later reads skip the parse.
+    setMemoryCachedKeys(address, sessionCached);
+    return sessionCached;
+  }
+
+  return null;
+}
+
+/**
+ * Check if the keys are already cached in memory or session storage.
+ * @param {string} address
+ * @returns {boolean}
+ */
+export function hasCachedKeys(address) {
+  return getCachedKeyPair(address) !== null;
+}
+
+/**
+ * Register the user's messaging public key on-chain.
+ *
+ * The contract method is still named `registerWakuPublicKey`; it is a
+ * transport-agnostic secp256k1 key registry and is already deployed, so
+ * the name is kept as-is.
+ *
+ * @param {import('ethers').Contract} contract - Chainvoice contract instance
+ * @param {Uint8Array} publicKey - the user's public key
+ * @returns {Promise<import('ethers').TransactionReceipt>}
+ */
+export async function registerPublicKeyOnChain(contract, publicKey) {
+  const tx = await contract.registerWakuPublicKey(bytesToHex(publicKey));
+  return await tx.wait();
+}
+
+/**
+ * Fetch a user's messaging public key from the on-chain registry.
+ *
+ * @param {import('ethers').Contract} contract - Chainvoice contract instance
+ * @param {string} userAddress - the address to look up
+ * @returns {Promise<Uint8Array|null>} - the public key bytes, or null if not registered
+ */
+export async function fetchPublicKeyFromChain(contract, userAddress) {
+  const keyHex = await contract.getWakuPublicKey(userAddress);
+  if (!keyHex || keyHex === '0x' || keyHex === '0x0' || keyHex.length <= 2) {
+    return null;
+  }
+
+  const publicKey = hexToBytes(keyHex);
+  // The current contract enforces this on registration, but an older or
+  // misconfigured deployment need not. Failing here beats handing a malformed
+  // key to eciesjs and surfacing its internal error instead.
+  if (
+    publicKey.length !== PUBLIC_KEY_BYTES ||
+    publicKey[0] !== UNCOMPRESSED_PREFIX
+  ) {
+    throw new Error(
+      `Registry returned a malformed public key for ${userAddress}: expected ${PUBLIC_KEY_BYTES} bytes starting 0x04, got ${publicKey.length} bytes`
+    );
+  }
+  return publicKey;
+}
+
+export { hexToBytes, bytesToHex, DERIVATION_MESSAGE };

--- a/frontend/src/utils/invoiceAmounts.js
+++ b/frontend/src/utils/invoiceAmounts.js
@@ -1,0 +1,47 @@
+import { ethers } from "ethers";
+
+/**
+ * Resolve the decimals to format an on-chain invoice amount with.
+ *
+ * Truthiness is not usable here: `0` is a legitimate decimals value, and a
+ * token whose metadata lookup failed leaves it undefined. Either one skipping
+ * the conversion would leave the amount in base units, which then flows into
+ * `parseUnits` and the native `value` of a payment — so this returns null
+ * rather than guessing, and callers drop the invoice instead of showing or
+ * paying a wrong figure.
+ *
+ * Shared by every page that renders an on-chain-only invoice. It decides
+ * payment amounts, so it must not be duplicated per page and allowed to drift.
+ *
+ * @param {Object} paymentToken - the invoice's payment token descriptor
+ * @returns {number|null} decimals, or null when they cannot be trusted
+ */
+export function resolveInvoiceDecimals(paymentToken) {
+  const raw = paymentToken?.decimals;
+  if (raw !== undefined && raw !== null && raw !== "") {
+    const parsedDecimals = Number(raw);
+    if (Number.isInteger(parsedDecimals) && parsedDecimals >= 0) {
+      return parsedDecimals;
+    }
+    return null;
+  }
+  // Native currency carries no ERC-20 metadata; every supported chain uses 18.
+  if (!paymentToken?.address || paymentToken.address === ethers.ZeroAddress) {
+    return 18;
+  }
+  return null;
+}
+
+/**
+ * Format a date for display, tolerating the nulls that on-chain-only invoices
+ * carry — the chain does not store invoice dates, so a stub has none.
+ *
+ * @param {string|number|Date|null|undefined} value
+ * @returns {string} a localised date-time, or an em dash placeholder
+ */
+export function formatInvoiceDate(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return date.toLocaleString();
+}

--- a/frontend/tests/services/invoiceCrypto.test.js
+++ b/frontend/tests/services/invoiceCrypto.test.js
@@ -1,0 +1,89 @@
+import { ethers } from "ethers";
+import {
+  encryptPayload,
+  decryptPayload,
+  tryDecryptPayload,
+  bytesToBase64,
+  base64ToBytes,
+} from "../../src/services/relay/invoiceCrypto.js";
+
+/** Derive a keypair the same way relayKeyManager does, without a wallet. */
+function keyPairFrom(seed) {
+  const privateKeyHex = ethers.keccak256(ethers.toUtf8Bytes(seed));
+  return {
+    privateKey: privateKeyHex,
+    publicKey: new ethers.SigningKey(privateKeyHex).publicKey,
+  };
+}
+
+const receiver = keyPairFrom("receiver");
+const stranger = keyPairFrom("stranger");
+
+const envelope = {
+  type: "invoice",
+  invoiceId: "7",
+  chainId: 11155111,
+  data: { amountDue: "125.5", client: { email: "bob@example.com" } },
+};
+
+describe("base64 helpers", () => {
+  it("round-trips arbitrary bytes", () => {
+    const bytes = new Uint8Array([0, 1, 127, 128, 255, 42]);
+    expect(Array.from(base64ToBytes(bytesToBase64(bytes)))).toEqual(
+      Array.from(bytes)
+    );
+  });
+
+  it("handles payloads larger than one chunk", () => {
+    const bytes = new Uint8Array(100_000).map((_, i) => i % 256);
+    expect(base64ToBytes(bytesToBase64(bytes))).toEqual(bytes);
+  });
+});
+
+describe("encryptPayload / decryptPayload", () => {
+  it("round-trips an invoice envelope", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, envelope);
+    expect(decryptPayload(receiver.privateKey, ciphertext)).toEqual(envelope);
+  });
+
+  it("produces base64 that does not leak plaintext", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, envelope);
+    expect(ciphertext).toMatch(/^[A-Za-z0-9+/]+=*$/);
+    expect(ciphertext).not.toContain("bob@example.com");
+  });
+
+  it("is non-deterministic (fresh ephemeral key per message)", () => {
+    const a = encryptPayload(receiver.publicKey, envelope);
+    const b = encryptPayload(receiver.publicKey, envelope);
+    expect(a).not.toBe(b);
+  });
+
+  it("serialises bigints rather than throwing", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, { amount: 10n });
+    expect(decryptPayload(receiver.privateKey, ciphertext)).toEqual({
+      amount: "10",
+    });
+  });
+
+  it("rejects decryption with the wrong key", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, envelope);
+    expect(() => decryptPayload(stranger.privateKey, ciphertext)).toThrow();
+  });
+});
+
+describe("tryDecryptPayload", () => {
+  it("returns the value when the key matches", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, envelope);
+    expect(tryDecryptPayload(receiver.privateKey, ciphertext)).toEqual(envelope);
+  });
+
+  it("returns null for another recipient's message", () => {
+    const ciphertext = encryptPayload(receiver.publicKey, envelope);
+    expect(tryDecryptPayload(stranger.privateKey, ciphertext)).toBeNull();
+  });
+
+  it("returns null for junk in the mailbox", () => {
+    expect(tryDecryptPayload(receiver.privateKey, "bm90LWNpcGhlcnRleHQ=")).toBeNull();
+    expect(tryDecryptPayload(receiver.privateKey, "!!!not base64!!!")).toBeNull();
+  });
+});

--- a/frontend/tests/services/invoiceHashUtils.test.js
+++ b/frontend/tests/services/invoiceHashUtils.test.js
@@ -1,0 +1,169 @@
+import {
+  computeInvoiceHash,
+  verifyInvoiceHash,
+  stableStringify,
+} from "../../src/services/relay/invoiceHashUtils.js";
+
+const invoice = {
+  amountDue: "125.5",
+  paymentToken: { address: "0xabc", symbol: "USDC", decimals: 6 },
+  user: { fname: "Ada", email: "ada@example.com" },
+  client: { fname: "Bob", email: "bob@example.com" },
+  items: [{ description: "Consulting", qty: "2", unitPrice: "50" }],
+};
+
+describe("stableStringify", () => {
+  it("is insensitive to key insertion order", () => {
+    const a = { x: 1, y: { p: 2, q: 3 } };
+    const b = { y: { q: 3, p: 2 }, x: 1 };
+    expect(stableStringify(a)).toBe(stableStringify(b));
+  });
+
+  it("preserves array order", () => {
+    expect(stableStringify([1, 2])).not.toBe(stableStringify([2, 1]));
+  });
+
+  it("serialises bigints as strings", () => {
+    expect(stableStringify({ n: 10n })).toBe('{"n":"10"}');
+  });
+
+  it("serialises dates as ISO strings", () => {
+    const date = new Date("2024-01-15T00:00:00.000Z");
+    expect(stableStringify({ d: date })).toBe('{"d":"2024-01-15T00:00:00.000Z"}');
+  });
+
+  it("omits undefined values", () => {
+    expect(stableStringify({ a: 1, b: undefined })).toBe('{"a":1}');
+  });
+
+  // The payload travels to the receiver as JSON, so anything stableStringify
+  // renders differently to JSON.stringify makes the two sides compute
+  // different hashes and silently fails verification.
+  describe("agrees with JSON.stringify on array edge cases", () => {
+    it("renders an undefined entry as null", () => {
+      expect(stableStringify([undefined])).toBe(JSON.stringify([undefined]));
+      expect(stableStringify([undefined])).toBe("[null]");
+    });
+
+    it("does not collide [undefined] with []", () => {
+      expect(stableStringify([undefined])).not.toBe(stableStringify([]));
+    });
+
+    it("renders sparse holes as null", () => {
+      const sparse = new Array(2);
+      sparse[1] = 1;
+      expect(stableStringify(sparse)).toBe(JSON.stringify(sparse));
+      expect(stableStringify(sparse)).toBe("[null,1]");
+    });
+
+    it("renders a trailing hole as null", () => {
+      const sparse = new Array(2);
+      sparse[0] = 1;
+      expect(stableStringify(sparse)).toBe(JSON.stringify(sparse));
+    });
+
+    it("renders nulls the same either way", () => {
+      expect(stableStringify([null, 1])).toBe(JSON.stringify([null, 1]));
+    });
+  });
+});
+
+describe("computeInvoiceHash", () => {
+  it("returns a 32-byte hex hash", () => {
+    expect(computeInvoiceHash(invoice)).toMatch(/^0x[0-9a-f]{64}$/);
+  });
+
+  it("is deterministic across key orderings", () => {
+    const reordered = {
+      items: invoice.items,
+      client: invoice.client,
+      user: invoice.user,
+      paymentToken: invoice.paymentToken,
+      amountDue: invoice.amountDue,
+    };
+    expect(computeInvoiceHash(reordered)).toBe(computeInvoiceHash(invoice));
+  });
+
+  it("changes when any field changes", () => {
+    const tampered = { ...invoice, amountDue: "125.6" };
+    expect(computeInvoiceHash(tampered)).not.toBe(computeInvoiceHash(invoice));
+  });
+
+  it("changes when a nested field changes", () => {
+    const tampered = {
+      ...invoice,
+      client: { ...invoice.client, email: "mallory@example.com" },
+    };
+    expect(computeInvoiceHash(tampered)).not.toBe(computeInvoiceHash(invoice));
+  });
+});
+
+describe("sender/receiver hash contract", () => {
+  // The sender hashes an in-memory object; the receiver hashes what comes back
+  // out of the relay's JSON. Anything that survives one but not the other makes
+  // the two sides disagree and silently fails verification, so assert over the
+  // round trip rather than over stableStringify alone.
+  const overTheWire = (value) =>
+    JSON.parse(
+      JSON.stringify(value, (_, v) => (typeof v === "bigint" ? v.toString() : v))
+    );
+
+  it("survives Date fields becoming ISO strings", () => {
+    const payload = {
+      issueDate: new Date("2026-08-06T07:00:00.000Z"),
+      dueDate: new Date("2026-09-01T10:30:00.000Z"),
+    };
+    expect(typeof overTheWire(payload).issueDate).toBe("string");
+    expect(computeInvoiceHash(overTheWire(payload))).toBe(
+      computeInvoiceHash(payload)
+    );
+  });
+
+  it("survives bigints becoming strings", () => {
+    const payload = { amountWei: 10n ** 18n };
+    expect(computeInvoiceHash(overTheWire(payload))).toBe(
+      computeInvoiceHash(payload)
+    );
+  });
+
+  it("survives undefined array entries becoming null", () => {
+    const payload = { items: [{ qty: "1" }, undefined] };
+    expect(computeInvoiceHash(overTheWire(payload))).toBe(
+      computeInvoiceHash(payload)
+    );
+  });
+
+  it("survives undefined object values being dropped", () => {
+    const payload = { user: { fname: "Ada", lname: undefined } };
+    expect(computeInvoiceHash(overTheWire(payload))).toBe(
+      computeInvoiceHash(payload)
+    );
+  });
+
+  it("survives a full invoice payload round trip", () => {
+    expect(computeInvoiceHash(overTheWire(invoice))).toBe(
+      computeInvoiceHash(invoice)
+    );
+  });
+});
+
+describe("verifyInvoiceHash", () => {
+  it("accepts matching data", () => {
+    expect(verifyInvoiceHash(invoice, computeInvoiceHash(invoice))).toBe(true);
+  });
+
+  it("is case-insensitive on the expected hash", () => {
+    const upper = computeInvoiceHash(invoice).toUpperCase().replace("0X", "0x");
+    expect(verifyInvoiceHash(invoice, upper)).toBe(true);
+  });
+
+  it("rejects tampered data", () => {
+    const expected = computeInvoiceHash(invoice);
+    expect(verifyInvoiceHash({ ...invoice, amountDue: "999" }, expected)).toBe(false);
+  });
+
+  it("rejects a missing hash", () => {
+    expect(verifyInvoiceHash(invoice, undefined)).toBe(false);
+    expect(verifyInvoiceHash(invoice, "")).toBe(false);
+  });
+});

--- a/frontend/tests/services/invoiceRoundTrip.test.js
+++ b/frontend/tests/services/invoiceRoundTrip.test.js
@@ -1,0 +1,130 @@
+import { ethers } from "ethers";
+import {
+  computeInvoiceHash,
+  verifyInvoiceHash,
+} from "../../src/services/relay/invoiceHashUtils.js";
+import {
+  encryptPayload,
+  decryptPayload,
+} from "../../src/services/relay/invoiceCrypto.js";
+
+/**
+ * The sender commits keccak256(payload) on-chain and ships the payload over
+ * the relay. The receiver only trusts the payload if it re-hashes to that
+ * commitment — so anything the transport does to the object's shape
+ * (Date coercion, bigint stringification, key reordering) breaks delivery.
+ * These tests pin that invariant.
+ */
+
+const receiverKey = ethers.keccak256(ethers.toUtf8Bytes("receiver"));
+const receiverPub = new ethers.SigningKey(receiverKey).publicKey;
+
+/** Mirrors the object CreateInvoice.jsx builds, Date instances included. */
+function buildInvoicePayload() {
+  return {
+    amountDue: "125.5",
+    dueDate: new Date("2026-09-01T10:30:00.000Z"),
+    issueDate: new Date("2026-08-06T07:00:00.000Z"),
+    paymentToken: {
+      address: "0x0000000000000000000000000000000000000000",
+      symbol: "ETH",
+      decimals: 18,
+    },
+    user: {
+      address: "0x69fF0f180e74112cF707DdDEC729095631c4B809",
+      fname: "Ada",
+      lname: "",
+      email: "ada@example.com",
+      country: "IN",
+      city: "Pune",
+      postalcode: "411001",
+    },
+    client: {
+      address: "0xF37B0B9f97e3B3a843d75Ef37F4eE8568590C900",
+      fname: "Bob",
+      lname: "Smith",
+      email: "bob@example.com",
+      country: "US",
+      city: "Austin",
+      postalcode: "73301",
+    },
+    items: [
+      {
+        id: "item-1",
+        description: "Consulting",
+        qty: "2",
+        unitPrice: "50",
+        discount: "10",
+        discountType: "amount",
+        tax: "10",
+        taxType: "percentage",
+        amount: "99",
+      },
+    ],
+  };
+}
+
+describe("invoice hash survives a relay round trip", () => {
+  it("re-hashes to the on-chain commitment after encrypt/decrypt", () => {
+    const payload = buildInvoicePayload();
+
+    // Sender: commit the hash on-chain, ship the payload encrypted.
+    const onChainHash = computeInvoiceHash(payload);
+    const ciphertext = encryptPayload(receiverPub, {
+      type: "invoice",
+      invoiceId: "7",
+      chainId: 11155111,
+      data: payload,
+    });
+
+    // Receiver: decrypt and verify against what the chain says.
+    const { data } = decryptPayload(receiverKey, ciphertext);
+    expect(verifyInvoiceHash(data, onChainHash)).toBe(true);
+  });
+
+  it("survives Date fields becoming ISO strings in transit", () => {
+    const payload = buildInvoicePayload();
+    // JSON has no Date type, so the receiver sees strings where the sender
+    // had Date objects. stableStringify must render both identically.
+    const overTheWire = JSON.parse(JSON.stringify(payload));
+
+    expect(typeof overTheWire.dueDate).toBe("string");
+    expect(overTheWire.dueDate).not.toBeInstanceOf(Date);
+    expect(computeInvoiceHash(overTheWire)).toBe(computeInvoiceHash(payload));
+  });
+
+  it("rejects a payload the sender altered after committing", () => {
+    const payload = buildInvoicePayload();
+    const onChainHash = computeInvoiceHash(payload);
+
+    // A malicious sender commits one amount on-chain and relays another.
+    const swapped = { ...payload, amountDue: "1.0" };
+    const ciphertext = encryptPayload(receiverPub, {
+      type: "invoice",
+      invoiceId: "7",
+      chainId: 11155111,
+      data: swapped,
+    });
+
+    const { data } = decryptPayload(receiverKey, ciphertext);
+    expect(verifyInvoiceHash(data, onChainHash)).toBe(false);
+  });
+
+  it("rejects a payload with an item quietly added", () => {
+    const payload = buildInvoicePayload();
+    const onChainHash = computeInvoiceHash(payload);
+
+    const padded = {
+      ...payload,
+      items: [...payload.items, { description: "Surprise fee", amount: "500" }],
+    };
+    expect(verifyInvoiceHash(padded, onChainHash)).toBe(false);
+  });
+
+  it("produces a bytes32-shaped hash the contract will accept", () => {
+    // createInvoice reverts on a zero hash and takes exactly bytes32.
+    const hash = computeInvoiceHash(buildInvoicePayload());
+    expect(hash).toMatch(/^0x[0-9a-f]{64}$/);
+    expect(hash).not.toBe(ethers.ZeroHash);
+  });
+});

--- a/frontend/tests/services/relayInvoiceMessaging.test.js
+++ b/frontend/tests/services/relayInvoiceMessaging.test.js
@@ -1,0 +1,521 @@
+import { jest } from "@jest/globals";
+import { ethers } from "ethers";
+
+// relayClient.js reads import.meta.env, which Jest cannot evaluate, and we want
+// a fake transport anyway — so stub the whole module before importing the SUT.
+const relayApi = {
+  send: jest.fn(),
+  receive: jest.fn(),
+  poll: jest.fn(),
+};
+
+jest.unstable_mockModule("../../src/services/relay/relayClient.js", () => ({
+  getRelayClient: () => relayApi,
+  RELAY_PROXY_PATH: "/relay",
+}));
+
+const { encryptPayload, decryptPayload } = await import(
+  "../../src/services/relay/invoiceCrypto.js"
+);
+const {
+  sendEncryptedInvoice,
+  fetchInvoiceMessages,
+  pollInvoiceMessages,
+  toMailboxAddress,
+  DEFAULT_POLL_INTERVAL_MS,
+} = await import("../../src/services/relay/relayInvoiceMessaging.js");
+
+function keyPairFrom(seed) {
+  const privateKey = ethers.keccak256(ethers.toUtf8Bytes(seed));
+  return { privateKey, publicKey: new ethers.SigningKey(privateKey).publicKey };
+}
+
+const receiver = keyPairFrom("receiver");
+const stranger = keyPairFrom("stranger");
+
+const RECEIVER_ADDR = "0xF37B0B9f97e3B3a843d75Ef37F4eE8568590C900";
+const SENDER_ADDR = "0x69fF0f180e74112cF707DdDEC729095631c4B809";
+const CHAIN_ID = 11155111;
+
+const invoiceData = { amountDue: "125.5", client: { email: "bob@example.com" } };
+
+/** Build a relay message carrying an envelope encrypted for `publicKey`. */
+function relayMessage(id, publicKey, overrides = {}) {
+  const envelope = {
+    type: "invoice",
+    invoiceId: "7",
+    chainId: CHAIN_ID,
+    timestamp: 1,
+    data: invoiceData,
+    ...overrides,
+  };
+  return {
+    id,
+    to: toMailboxAddress(RECEIVER_ADDR),
+    from: toMailboxAddress(SENDER_ADDR),
+    payload: encryptPayload(publicKey, envelope),
+  };
+}
+
+beforeEach(() => {
+  relayApi.send.mockReset();
+  relayApi.receive.mockReset();
+  relayApi.poll.mockReset();
+});
+
+describe("toMailboxAddress", () => {
+  it("lowercases addresses so relay lookups match", () => {
+    // The relay matches `to` by exact string, so a checksummed address would
+    // be invisible to a client polling the lowercase form.
+    expect(toMailboxAddress(RECEIVER_ADDR)).toBe(RECEIVER_ADDR.toLowerCase());
+  });
+
+  it.each(["", null, undefined])("throws on a missing address (%p)", (value) => {
+    expect(() => toMailboxAddress(value)).toThrow(/address is required/i);
+  });
+});
+
+describe("sendEncryptedInvoice", () => {
+  it("posts a ciphertext addressed to lowercased participants", async () => {
+    relayApi.send.mockResolvedValue({ id: "msg-1" });
+
+    await sendEncryptedInvoice({
+      invoiceData,
+      receiverPublicKey: receiver.publicKey,
+      receiverAddress: RECEIVER_ADDR,
+      senderAddress: SENDER_ADDR,
+      chainId: CHAIN_ID,
+      invoiceId: 7,
+    });
+
+    expect(relayApi.send).toHaveBeenCalledTimes(1);
+    const sent = relayApi.send.mock.calls[0][0];
+    expect(sent.to).toBe(RECEIVER_ADDR.toLowerCase());
+    expect(sent.from).toBe(SENDER_ADDR.toLowerCase());
+    expect(sent.payload).not.toContain("bob@example.com");
+
+    // Assert the envelope the send path actually built, rather than trusting
+    // the fixture to mirror it — the receiver's chain filter and dedupe key
+    // both depend on these exact fields.
+    const envelope = decryptPayload(receiver.privateKey, sent.payload);
+    expect(envelope).toMatchObject({
+      type: "invoice",
+      invoiceId: "7",
+      chainId: CHAIN_ID,
+      data: invoiceData,
+    });
+    expect(typeof envelope.invoiceId).toBe("string");
+    expect(typeof envelope.timestamp).toBe("number");
+  });
+
+  // A NaN chainId serialises to null and never matches the receiver's chain
+  // filter, so the message would be accepted by the relay and silently
+  // discarded forever while the sender is told it succeeded.
+  it.each([undefined, null, "not-a-chain", NaN])(
+    "refuses to build an envelope with chainId %p",
+    async (chainId) => {
+      await expect(
+        sendEncryptedInvoice({
+          invoiceData,
+          receiverPublicKey: receiver.publicKey,
+          receiverAddress: RECEIVER_ADDR,
+          senderAddress: SENDER_ADDR,
+          chainId,
+          invoiceId: 7,
+        })
+      ).rejects.toThrow(/chainId/i);
+      expect(relayApi.send).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([undefined, null, ""])(
+    "refuses to build an envelope with invoiceId %p",
+    async (invoiceId) => {
+      await expect(
+        sendEncryptedInvoice({
+          invoiceData,
+          receiverPublicKey: receiver.publicKey,
+          receiverAddress: RECEIVER_ADDR,
+          senderAddress: SENDER_ADDR,
+          chainId: CHAIN_ID,
+          invoiceId,
+        })
+      ).rejects.toThrow(/invoiceId/i);
+      expect(relayApi.send).not.toHaveBeenCalled();
+    }
+  );
+
+  it("accepts invoice id 0", async () => {
+    // Falsy but valid — the contract numbers the first invoice 0.
+    relayApi.send.mockResolvedValue({ id: "msg-1" });
+    await sendEncryptedInvoice({
+      invoiceData,
+      receiverPublicKey: receiver.publicKey,
+      receiverAddress: RECEIVER_ADDR,
+      senderAddress: SENDER_ADDR,
+      chainId: CHAIN_ID,
+      invoiceId: 0,
+    });
+    expect(relayApi.send).toHaveBeenCalledTimes(1);
+  });
+
+  it("refuses to send without a recipient key", async () => {
+    await expect(
+      sendEncryptedInvoice({
+        invoiceData,
+        receiverPublicKey: null,
+        receiverAddress: RECEIVER_ADDR,
+        senderAddress: SENDER_ADDR,
+        chainId: CHAIN_ID,
+        invoiceId: 7,
+      })
+    ).rejects.toThrow(/public key/i);
+    expect(relayApi.send).not.toHaveBeenCalled();
+  });
+});
+
+describe("fetchInvoiceMessages", () => {
+  it("decrypts messages addressed to this key", async () => {
+    relayApi.receive.mockResolvedValue([relayMessage("m1", receiver.publicKey)]);
+
+    const result = await fetchInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].messageId).toBe("m1");
+    expect(result[0].envelope.data).toEqual(invoiceData);
+  });
+
+  it("queries the lowercased mailbox", async () => {
+    relayApi.receive.mockResolvedValue([]);
+    await fetchInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+    });
+    expect(relayApi.receive).toHaveBeenCalledWith(RECEIVER_ADDR.toLowerCase());
+  });
+
+  it("skips messages it cannot decrypt", async () => {
+    relayApi.receive.mockResolvedValue([
+      relayMessage("m1", stranger.publicKey),
+      { id: "m2", payload: "junk" },
+      { id: "m3" },
+      relayMessage("m4", receiver.publicKey),
+    ]);
+
+    const result = await fetchInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+    });
+
+    expect(result.map((r) => r.messageId)).toEqual(["m4"]);
+  });
+
+  it("filters out other chains", async () => {
+    relayApi.receive.mockResolvedValue([
+      relayMessage("m1", receiver.publicKey, { chainId: 137 }),
+      relayMessage("m2", receiver.publicKey),
+    ]);
+
+    const result = await fetchInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+    });
+
+    expect(result.map((r) => r.messageId)).toEqual(["m2"]);
+  });
+
+  it("ignores envelopes of an unknown type or shape", async () => {
+    relayApi.receive.mockResolvedValue([
+      relayMessage("m1", receiver.publicKey, { type: "something-else" }),
+      relayMessage("m2", receiver.publicKey, { data: undefined }),
+      relayMessage("m3", receiver.publicKey, { invoiceId: undefined }),
+    ]);
+
+    const result = await fetchInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+    });
+
+    expect(result).toEqual([]);
+  });
+});
+
+describe("pollInvoiceMessages", () => {
+  /** Capture the callback and options the SDK's poll() would receive. */
+  function capturePoll() {
+    let onMessages;
+    let options;
+    const stop = jest.fn();
+    relayApi.poll.mockImplementation((address, cb, opts) => {
+      onMessages = cb;
+      options = opts;
+      return stop;
+    });
+    return {
+      pump: (msgs) => onMessages(msgs),
+      stop,
+      getOptions: () => options,
+    };
+  }
+
+  it("forwards intervalMs to the SDK", () => {
+    const { getOptions } = capturePoll();
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice: jest.fn(),
+      intervalMs: 5000,
+    });
+    expect(getOptions().intervalMs).toBe(5000);
+  });
+
+  it("defaults intervalMs when not given", () => {
+    const { getOptions } = capturePoll();
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice: jest.fn(),
+    });
+    expect(getOptions().intervalMs).toBe(DEFAULT_POLL_INTERVAL_MS);
+  });
+
+  it("delegates poll failures to onError", () => {
+    const { getOptions } = capturePoll();
+    const onError = jest.fn();
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice: jest.fn(),
+      onError,
+    });
+
+    const failure = new Error("relay unreachable");
+    getOptions().onError(failure);
+
+    expect(onError).toHaveBeenCalledWith(failure);
+  });
+
+  it("suppresses errors raised after stopping", () => {
+    const { getOptions } = capturePoll();
+    const onError = jest.fn();
+    const stopPolling = pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice: jest.fn(),
+      onError,
+    });
+
+    stopPolling();
+    getOptions().onError(new Error("in flight when stopped"));
+
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it("emits each message only once across polls", async () => {
+    const { pump } = capturePoll();
+    const onInvoice = jest.fn();
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    // The relay has no cursor, so every poll returns the whole mailbox.
+    const batch = [relayMessage("m1", receiver.publicKey)];
+    await pump(batch);
+    await pump(batch);
+
+    expect(onInvoice).toHaveBeenCalledTimes(1);
+  });
+
+  it("emits newly arrived messages on a later poll", async () => {
+    const { pump } = capturePoll();
+    const onInvoice = jest.fn();
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    await pump([relayMessage("m1", receiver.publicKey)]);
+    await pump([
+      relayMessage("m1", receiver.publicKey),
+      relayMessage("m2", receiver.publicKey),
+    ]);
+
+    expect(onInvoice).toHaveBeenCalledTimes(2);
+    expect(onInvoice.mock.calls[1][0].messageId).toBe("m2");
+  });
+
+  it("honours knownMessageIds so stored invoices are not re-announced", async () => {
+    const { pump } = capturePoll();
+    const onInvoice = jest.fn();
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+      knownMessageIds: ["m1"],
+    });
+
+    await pump([relayMessage("m1", receiver.publicKey)]);
+    expect(onInvoice).not.toHaveBeenCalled();
+  });
+
+  it("stops emitting after the stop function is called", async () => {
+    const { pump, stop } = capturePoll();
+    const onInvoice = jest.fn();
+
+    const stopPolling = pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    stopPolling();
+    await pump([relayMessage("m1", receiver.publicKey)]);
+
+    expect(stop).toHaveBeenCalled();
+    expect(onInvoice).not.toHaveBeenCalled();
+  });
+
+  it("does not double-process when two polls overlap", async () => {
+    // The SDK calls the poll callback without awaiting it before scheduling the
+    // next tick, so two cycles can run concurrently over the same mailbox. The
+    // messageId is claimed before the handler is awaited precisely so the
+    // second cycle skips it; without that, this delivers twice.
+    const { pump } = capturePoll();
+    let releaseHandler;
+    const handlerStarted = new Promise((resolve) => {
+      releaseHandler = resolve;
+    });
+    const onInvoice = jest.fn(() => handlerStarted);
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    const batch = [relayMessage("m1", receiver.publicKey)];
+    // Start both cycles before letting the first handler finish.
+    const first = pump(batch);
+    const second = pump(batch);
+    releaseHandler();
+    await Promise.all([first, second]);
+
+    expect(onInvoice).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a message whose handler threw", async () => {
+    // A transient failure — a rejected IndexedDB write, say — must not bury
+    // the invoice. The message stays unclaimed so the next poll re-delivers it.
+    const { pump } = capturePoll();
+    const onInvoice = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("indexeddb blew up"))
+      .mockResolvedValue(undefined);
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    await pump([relayMessage("m1", receiver.publicKey)]);
+    await pump([relayMessage("m1", receiver.publicKey)]);
+
+    const delivered = onInvoice.mock.calls.map((c) => c[0].messageId);
+    expect(delivered).toEqual(["m1", "m1"]);
+  });
+
+  it("does not re-deliver once the handler finally succeeds", async () => {
+    const { pump } = capturePoll();
+    const onInvoice = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue(undefined);
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    const batch = [relayMessage("m1", receiver.publicKey)];
+    await pump(batch); // fails, released
+    await pump(batch); // succeeds, claimed
+    await pump(batch); // already seen
+
+    expect(onInvoice.mock.calls.map((c) => c[0].messageId)).toEqual(["m1", "m1"]);
+  });
+
+  it("stops mid-batch when the stop function is called from a handler", async () => {
+    // pollInvoiceMessages re-checks `stopped` inside the message loop; without
+    // that, the rest of the batch is still delivered after teardown.
+    const { pump } = capturePoll();
+    let stopPolling;
+    const onInvoice = jest.fn(() => {
+      stopPolling();
+    });
+
+    stopPolling = pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    await pump([
+      relayMessage("m1", receiver.publicKey),
+      relayMessage("m2", receiver.publicKey),
+      relayMessage("m3", receiver.publicKey),
+    ]);
+
+    expect(onInvoice).toHaveBeenCalledTimes(1);
+    expect(onInvoice.mock.calls[0][0].messageId).toBe("m1");
+  });
+
+  it("keeps processing later messages after one handler throws", async () => {
+    const { pump } = capturePoll();
+    const onInvoice = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("indexeddb blew up"))
+      .mockResolvedValue(undefined);
+
+    pollInvoiceMessages({
+      privateKey: receiver.privateKey,
+      address: RECEIVER_ADDR,
+      chainId: CHAIN_ID,
+      onInvoice,
+    });
+
+    await pump([
+      relayMessage("m1", receiver.publicKey),
+      relayMessage("m2", receiver.publicKey),
+    ]);
+
+    expect(onInvoice.mock.calls.map((c) => c[0].messageId)).toEqual(["m1", "m2"]);
+  });
+});

--- a/frontend/tests/services/relayKeyManager.test.js
+++ b/frontend/tests/services/relayKeyManager.test.js
@@ -1,0 +1,385 @@
+import { jest } from "@jest/globals";
+import { ethers } from "ethers";
+import {
+  deriveRelayKeyPair,
+  clearCachedKeys,
+  hasCachedKeys,
+  fetchPublicKeyFromChain,
+  registerPublicKeyOnChain,
+  hexToBytes,
+  bytesToHex,
+  DERIVATION_MESSAGE,
+} from "../../src/services/relay/relayKeyManager.js";
+
+const ADDRESS = "0x69fF0f180e74112cF707DdDEC729095631c4B809";
+
+/** Minimal sessionStorage stand-in; jsdom is not configured for these tests. */
+function installSessionStorage() {
+  const store = new Map();
+  globalThis.sessionStorage = {
+    getItem: (k) => (store.has(k) ? store.get(k) : null),
+    setItem: (k, v) => store.set(k, String(v)),
+    removeItem: (k) => store.delete(k),
+    clear: () => store.clear(),
+    _store: store,
+  };
+  return store;
+}
+
+/** A signer that records how many times it was asked to sign. */
+function makeSigner() {
+  const wallet = new ethers.Wallet(
+    ethers.keccak256(ethers.toUtf8Bytes("test-wallet"))
+  );
+  const signMessage = jest.fn((msg) => wallet.signMessage(msg));
+  return { signMessage };
+}
+
+let store;
+beforeEach(() => {
+  store = installSessionStorage();
+  clearCachedKeys(ADDRESS);
+});
+
+describe("deriveRelayKeyPair", () => {
+  it("derives a 65-byte uncompressed key the contract will accept", async () => {
+    // The registry rejects anything that is not 65 bytes starting 0x04.
+    const { publicKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    expect(publicKey).toHaveLength(65);
+    expect(publicKey[0]).toBe(0x04);
+  });
+
+  it("derives the same keypair for the same wallet", async () => {
+    const a = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    clearCachedKeys(ADDRESS);
+    const b = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    expect(bytesToHex(a.publicKey)).toBe(bytesToHex(b.publicKey));
+  });
+
+  it("signs exactly once, then serves from the memory cache", async () => {
+    const signer = makeSigner();
+    await deriveRelayKeyPair(signer, ADDRESS);
+    await deriveRelayKeyPair(signer, ADDRESS);
+    expect(signer.signMessage).toHaveBeenCalledTimes(1);
+  });
+
+  it("signs the documented derivation message", async () => {
+    const signer = makeSigner();
+    await deriveRelayKeyPair(signer, ADDRESS);
+    expect(signer.signMessage).toHaveBeenCalledWith(DERIVATION_MESSAGE);
+  });
+
+  it("treats addresses case-insensitively", async () => {
+    const signer = makeSigner();
+    await deriveRelayKeyPair(signer, ADDRESS);
+    await deriveRelayKeyPair(signer, ADDRESS.toLowerCase());
+    expect(signer.signMessage).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("session persistence", () => {
+  // Regression: keys used to be memory-only by default, so a page reload lost
+  // the private key. Anything gated on key availability — notably relay
+  // polling — then never restarted, and the inbox silently stopped working.
+
+  it("survives a reload when rememberSession is set", async () => {
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+
+    // Simulate a reload: module memory is gone, sessionStorage is not.
+    jest.resetModules();
+    const reloaded = await import("../../src/services/relay/relayKeyManager.js");
+
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(true);
+  });
+
+  it("does not survive a reload when rememberSession is not set", async () => {
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, false);
+
+    jest.resetModules();
+    const reloaded = await import("../../src/services/relay/relayKeyManager.js");
+
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(false);
+  });
+
+  it("restores the identical key from session cache without signing again", async () => {
+    const original = await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+
+    jest.resetModules();
+    const reloaded = await import("../../src/services/relay/relayKeyManager.js");
+
+    const signer = makeSigner();
+    const restored = await reloaded.deriveRelayKeyPair(signer, ADDRESS, true);
+
+    expect(signer.signMessage).not.toHaveBeenCalled();
+    expect(bytesToHex(restored.privateKey)).toBe(bytesToHex(original.privateKey));
+    expect(bytesToHex(restored.publicKey)).toBe(bytesToHex(original.publicKey));
+  });
+
+  it("keys the session entry by address so accounts do not collide", async () => {
+    const other = "0x6F7458D1c14F4153A4092Af4f3A521111Bc04C59";
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+
+    expect(hasCachedKeys(ADDRESS)).toBe(true);
+    expect([...store.keys()].some((k) => k.includes(ADDRESS.toLowerCase()))).toBe(true);
+    expect([...store.keys()].some((k) => k.includes(other.toLowerCase()))).toBe(false);
+  });
+
+  it("clearCachedKeys wipes both memory and session", async () => {
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+    expect(hasCachedKeys(ADDRESS)).toBe(true);
+
+    clearCachedKeys(ADDRESS);
+
+    expect(hasCachedKeys(ADDRESS)).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it("ignores a corrupted session entry rather than throwing", async () => {
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+    const key = [...store.keys()][0];
+    store.set(key, "not json");
+
+    jest.resetModules();
+    const reloaded = await import("../../src/services/relay/relayKeyManager.js");
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(false);
+  });
+});
+
+describe("fetchPublicKeyFromChain", () => {
+  // This decides whether the sender encrypts a payload or falls back to the
+  // on-chain summary, so every "unregistered" shape has to be recognised.
+  const contractReturning = (value) => ({
+    getWakuPublicKey: jest.fn().mockResolvedValue(value),
+  });
+
+  it.each(["0x", "0x0", ""])(
+    "treats %p as unregistered",
+    async (value) => {
+      expect(
+        await fetchPublicKeyFromChain(contractReturning(value), ADDRESS)
+      ).toBeNull();
+    }
+  );
+
+  it.each([null, undefined])("treats %p as unregistered", async (value) => {
+    expect(
+      await fetchPublicKeyFromChain(contractReturning(value), ADDRESS)
+    ).toBeNull();
+  });
+
+  it("returns the key bytes when one is registered", async () => {
+    const { publicKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    const hex = bytesToHex(publicKey);
+
+    const result = await fetchPublicKeyFromChain(contractReturning(hex), ADDRESS);
+
+    expect(result).toEqual(publicKey);
+    expect(result).toHaveLength(65);
+  });
+
+  it.each([
+    ["too short", "0x04aabbcc"],
+    ["wrong prefix", "0x03" + "11".repeat(64)],
+    ["too long", "0x04" + "11".repeat(70)],
+  ])("throws on a malformed registry key (%s)", async (_label, value) => {
+    await expect(
+      fetchPublicKeyFromChain(contractReturning(value), ADDRESS)
+    ).rejects.toThrow(/malformed public key/i);
+  });
+
+  it("looks up the address it was given", async () => {
+    const contract = contractReturning("0x");
+    await fetchPublicKeyFromChain(contract, ADDRESS);
+    expect(contract.getWakuPublicKey).toHaveBeenCalledWith(ADDRESS);
+  });
+});
+
+describe("registerPublicKeyOnChain", () => {
+  it("submits the key as hex and waits for the receipt", async () => {
+    const { publicKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    const wait = jest.fn().mockResolvedValue({ status: 1 });
+    const contract = {
+      registerWakuPublicKey: jest.fn().mockResolvedValue({ wait }),
+    };
+
+    const receipt = await registerPublicKeyOnChain(contract, publicKey);
+
+    expect(contract.registerWakuPublicKey).toHaveBeenCalledWith(bytesToHex(publicKey));
+    expect(wait).toHaveBeenCalled();
+    expect(receipt).toEqual({ status: 1 });
+  });
+
+  it("submits a 65-byte 0x04-prefixed key, as the contract requires", async () => {
+    const { publicKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS);
+    const contract = {
+      registerWakuPublicKey: jest
+        .fn()
+        .mockResolvedValue({ wait: jest.fn().mockResolvedValue({}) }),
+    };
+
+    await registerPublicKeyOnChain(contract, publicKey);
+
+    const submitted = contract.registerWakuPublicKey.mock.calls[0][0];
+    expect(submitted).toMatch(/^0x04[0-9a-f]{128}$/);
+  });
+});
+
+describe("malformed cache entries", () => {
+  // The corrupted entry has to survive into the read path. clearCachedKeys
+  // cannot be used to reset here: it calls sessionStorage.removeItem, which
+  // deletes the entry before the assertion, so the test would pass on
+  // "nothing stored" rather than on the size checks rejecting it.
+  const corruptThenReload = async (value) => {
+    const key = [...store.keys()][0];
+    store.set(key, JSON.stringify(value));
+    jest.resetModules();
+    return import("../../src/services/relay/relayKeyManager.js");
+  };
+
+  it("rejects a truncated private key", async () => {
+    const { publicKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+    const reloaded = await corruptThenReload({
+      privateKey: "0xdeadbeef",
+      publicKey: bytesToHex(publicKey),
+    });
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(false);
+  });
+
+  it("rejects a truncated public key", async () => {
+    const { privateKey } = await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+    const reloaded = await corruptThenReload({
+      privateKey: bytesToHex(privateKey),
+      publicKey: "0x04aabb",
+    });
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(false);
+  });
+
+  it("rejects a public key without the uncompressed prefix", async () => {
+    const { privateKey, publicKey } = await deriveRelayKeyPair(
+      makeSigner(),
+      ADDRESS,
+      true
+    );
+    const wrongPrefix = new Uint8Array(publicKey);
+    wrongPrefix[0] = 0x03;
+    const reloaded = await corruptThenReload({
+      privateKey: bytesToHex(privateKey),
+      publicKey: bytesToHex(wrongPrefix),
+    });
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(false);
+  });
+
+  it("accepts a well-formed entry, proving the checks are not blanket-rejecting", async () => {
+    const { privateKey, publicKey } = await deriveRelayKeyPair(
+      makeSigner(),
+      ADDRESS,
+      true
+    );
+    const reloaded = await corruptThenReload({
+      privateKey: bytesToHex(privateKey),
+      publicKey: bytesToHex(publicKey),
+    });
+    expect(reloaded.hasCachedKeys(ADDRESS)).toBe(true);
+  });
+
+  it("drops the bad entry so the next call re-derives", async () => {
+    await deriveRelayKeyPair(makeSigner(), ADDRESS, true);
+    const reloaded = await corruptThenReload({
+      privateKey: "0xdeadbeef",
+      publicKey: "0x04aabb",
+    });
+
+    expect(reloaded.getCachedKeyPair(ADDRESS)).toBeNull();
+    expect(store.size).toBe(0);
+  });
+});
+
+describe("concurrent derivation", () => {
+  it("shares one signature prompt between concurrent callers", async () => {
+    // Two components can ask for the key at once; the in-flight promise is
+    // shared so the user is not asked to sign twice.
+    let complete;
+    const signMessage = jest.fn(
+      () => new Promise((resolve) => { complete = resolve; })
+    );
+    const wallet = new ethers.Wallet(
+      ethers.keccak256(ethers.toUtf8Bytes("test-wallet"))
+    );
+
+    const first = deriveRelayKeyPair({ signMessage }, ADDRESS, true);
+    const second = deriveRelayKeyPair({ signMessage }, ADDRESS, true);
+    complete(await wallet.signMessage(DERIVATION_MESSAGE));
+    const [a, b] = await Promise.all([first, second]);
+
+    expect(signMessage).toHaveBeenCalledTimes(1);
+    expect(bytesToHex(a.privateKey)).toBe(bytesToHex(b.privateKey));
+  });
+});
+
+describe("clearing during an in-flight derivation", () => {
+  /** A signer whose signature can be completed on demand. */
+  function deferredSigner() {
+    let complete;
+    const signMessage = jest.fn(
+      () => new Promise((resolve) => { complete = resolve; })
+    );
+    const wallet = new ethers.Wallet(
+      ethers.keccak256(ethers.toUtf8Bytes("test-wallet"))
+    );
+    return {
+      signer: { signMessage },
+      finish: async () => complete(await wallet.signMessage(DERIVATION_MESSAGE)),
+    };
+  }
+
+  it("does not restore the key after it was cleared", async () => {
+    // Disconnecting while a signature prompt is still open must not have the
+    // key written back once the user finally signs.
+    const { signer, finish } = deferredSigner();
+
+    const pending = deriveRelayKeyPair(signer, ADDRESS, true);
+    clearCachedKeys(ADDRESS);
+    await finish();
+    await pending;
+
+    expect(hasCachedKeys(ADDRESS)).toBe(false);
+    expect(store.size).toBe(0);
+  });
+
+  it("still returns the derived pair to its caller", async () => {
+    const { signer, finish } = deferredSigner();
+
+    const pending = deriveRelayKeyPair(signer, ADDRESS, true);
+    clearCachedKeys(ADDRESS);
+    await finish();
+
+    const keyPair = await pending;
+    expect(keyPair.publicKey).toHaveLength(65);
+  });
+
+  it("caches normally when nothing cleared it", async () => {
+    const { signer, finish } = deferredSigner();
+
+    const pending = deriveRelayKeyPair(signer, ADDRESS, true);
+    await finish();
+    await pending;
+
+    expect(hasCachedKeys(ADDRESS)).toBe(true);
+  });
+});
+
+describe("hex helpers", () => {
+  it("round-trips bytes", () => {
+    const bytes = new Uint8Array([0x04, 0x00, 0xff, 0x7f]);
+    expect(hexToBytes(bytesToHex(bytes))).toEqual(bytes);
+  });
+
+  it("accepts hex with or without the 0x prefix", () => {
+    expect(hexToBytes("0x04ff")).toEqual(hexToBytes("04ff"));
+  });
+
+  it("rejects malformed hex", () => {
+    expect(() => hexToBytes("0xabc")).toThrow(/odd length/i);
+    expect(() => hexToBytes("0xzz")).toThrow(/non-hex/i);
+  });
+});

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,18 +1,35 @@
 import path from "path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, loadEnv } from "vite"
 import { nodePolyfills } from 'vite-plugin-node-polyfills'
 
-export default defineConfig({
-  plugins: [react(), nodePolyfills({ include: ['buffer', 'crypto', 'stream', 'util'] })],
-  base:'/',
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+
+  return {
+    plugins: [react(), nodePolyfills({ include: ['buffer', 'crypto', 'stream', 'util'] })],
+    base:'/',
+    resolve: {
+      alias: {
+        "@": path.resolve(__dirname, "./src"),
+      },
     },
-  },
-  build: {
-    chunkSizeWarningLimit: 1500
+    server: {
+      proxy: {
+        // The ThruBox relay serves no CORS headers, so the browser cannot reach
+        // it cross-origin: the preflight for POST /api/messages is rejected and
+        // GET responses carry no Access-Control-Allow-Origin. Proxying keeps dev
+        // requests same-origin. Production is expected to reach the relay
+        // through a reverse proxy that supplies CORS.
+        '/relay': {
+          target: env.VITE_RELAY_URL || 'http://localhost:3000',
+          changeOrigin: true,
+          rewrite: (p) => p.replace(/^\/relay/, ''),
+        },
+      },
+    },
+    build: {
+      chunkSizeWarningLimit: 1500
+    }
   }
 })
-


### PR DESCRIPTION
###  Addressed Issues:

Fixes #139


###  Screenshots/Recordings:

<!-- ▶️ PASTE VIDEO HERE — drag the .mp4/.mov file into this box on GitHub -->

_Full flow: register key → create invoice → payload encrypted and relayed → receiver decrypts → hash verified against the on-chain commitment._

**Before:** the invoice payload was written to the chain as plain base64, readable by anyone with an RPC endpoint.
**After:** the chain holds only `keccak256(payload)`; the payload itself travels encrypted and is verified on arrival.


###  Additional Notes:

Since Lit Protocol was removed, invoice payloads have been written to the chain as plain base64 — **readable by anyone**. This moves them off-chain: the contract records only `keccak256(payload)`, and the payload itself is ECIES-encrypted to the recipient's registered key and posted to the relay.

#### Send — `CreateInvoice`, `CreateInvoicesBatch`

Compute the hash, pass it as `bytes32`, then look up the recipient's key and post the ciphertext. Delivery is best-effort and never rolls back a confirmed invoice: a recipient who has not registered a key yet, or a relay that is briefly down, leaves the invoice on-chain and flagged as undelivered rather than failing the whole operation.

#### Receive — `ReceivedInvoice`

Payloads arrive over the relay into IndexedDB. Relay ingestion is its **own** effect, deliberately outside the refresh cycle: storing a message bumps a refresh trigger, and if that re-ran ingestion it would re-read the same mailbox and loop forever. Only invoices not already in IndexedDB count as new, since every poll returns the whole mailbox.

#### Read — all pages

The payload is recomputed into a hash and compared against the chain before being trusted. **This closes step 6 of the intended design, which the Waku implementation defined but never called anywhere** — `verifyInvoiceHash` existed with zero call sites, so the tamper check was a no-op. A payload that fails verification is not rendered; the invoice falls back to the on-chain amount and addresses, marked *Unverified*, so a tampered payload can neither be shown as genuine nor hide the invoice entirely.

#### Resend — `SentInvoice`

Waku's Store protocol retained messages network-side, so a client could always catch up. The relay only holds what was successfully posted, so an undelivered invoice would otherwise be stranded on the sender's device forever. Undelivered invoices now expose a resend action.

#### Deploy workflow

The Pages workflow gains the relay variables. Vite inlines env at build time, so without them a production build ships the localhost fallback, which the browser blocks as mixed content from an https origin.

#### Verification

Verified end-to-end against a local relay and a deployed Sepolia contract: key derivation is stable, the payload re-hashes to the on-chain commitment after an encrypt/relay/decrypt round trip, non-recipients cannot decrypt, and altered payloads fail verification.

`tests/services/invoiceRoundTrip.test.js` pins the invariant that breaks most easily — `Date` fields become ISO strings in transit, so `stableStringify` must render both identically or every delivery fails verification.

**Review order:** requires #193 and #194. Must not land before #193, or callers pass old string arguments to a 4-argument function.

### AI Usage Disclosure:

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: **Claude Code (CLI), model Claude Opus 5**


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added encrypted relay delivery for invoice details, wallet-based key setup, and invoice resend support.
  * Invoice records now use verifiable on-chain hashes while sensitive details remain off-chain.
  * Added batch invoice creation and delivery with progress and failure reporting.
  * Added warnings and limited on-chain invoice views when details are unavailable or unverified.
  * Added relay health, timeout, proxy, and API-key configuration options.

* **Documentation**
  * Updated Sepolia contract addresses and documented deployment status for Ethereum Classic and Polygon.
  * Added relay setup and security configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->