### PR TITLE
fix: report PR test/build results from a workflow_run job

### DIFF
--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -15,8 +15,17 @@ permissions:
   pull-requests: write
   actions: read
 
+# One report in flight per head branch. Without this, two pushes in quick
+# succession race: both runs list the comments, both see no existing report, and
+# both create one. The newest run always has the freshest results, so superseding
+# an in-flight one loses nothing.
+concurrency:
+  group: pr-report-${{ github.event.workflow_run.head_repository.full_name }}-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
 jobs:
   report:
+    name: Label and comment
     if: github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
@@ -25,7 +34,7 @@ jobs:
       - name: Download report data
         id: download
         continue-on-error: true
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: pr-report
           path: pr-report
@@ -34,11 +43,40 @@ jobs:
 
       - name: Label and comment
         if: steps.download.outcome == 'success'
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
             const fs = require('fs');
             const { owner, repo } = context.repo;
+            const run = context.payload.workflow_run;
+
+            // Which PR to write to is decided from the event payload alone, never
+            // from the artifact. A `pull_request` run executes the fork's own copy
+            // of test.yml, so every byte of that artifact is attacker-controlled: a
+            // PR that wrote someone else's number into it could drive labels and
+            // bot comments onto any issue in this repo.
+            const findPullRequest = async () => {
+              // Populated only when head and base are the same repo.
+              if (run.pull_requests?.length) return run.pull_requests[0].number;
+              const prs = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                head: `${run.head_repository.owner.login}:${run.head_branch}`,
+                per_page: 100,
+              });
+              // Prefer the exact commit; a newer push leaves this run's sha behind,
+              // and the branch match is still the right PR.
+              return (prs.find((pr) => pr.head.sha === run.head_sha) ?? prs[0])?.number;
+            };
+
+            const prNumber = await findPullRequest();
+            if (!prNumber) {
+              core.info(
+                `No open PR for ${run.head_repository.full_name}:${run.head_branch}; nothing to report.`,
+              );
+              return;
+            }
 
             const read = (name) => {
               try {
@@ -48,20 +86,17 @@ jobs:
               }
             };
 
-            const prNumber = Number(read('pr_number').trim());
-            if (!prNumber) {
-              core.info('No PR number in artifact; nothing to report.');
-              return;
-            }
-
+            // Advisory only. A fork controls its own copy of test.yml and could
+            // claim anything here; the authoritative pass/fail signal is the
+            // required check's own conclusion, which this cannot influence.
             const testsFailed = read('tests_failed').trim() === 'true';
             const buildFailed = read('build_failed').trim() === 'true';
 
             // Artifact contents come from a fork's build. Fence-breaking is the
             // only thing quoting it can do, but neuter it anyway.
-            const fence = (text, limit = 60000) => {
+            const fence = (text, limit) => {
               let out = text.replace(/`/g, 'ˋ');
-              if (out.length > limit) out = out.slice(-limit);
+              if (out.length > limit) out = `…(truncated)\n${out.slice(-limit)}`;
               return out.trim() || '(no output)';
             };
 
@@ -97,42 +132,60 @@ jobs:
             const sections = [];
 
             if (testsFailed) {
-              sections.push(
-                `⚠️ **Tests failed!**\n\n<details><summary>Test Output</summary>\n\n\`\`\`\n` +
-                `${fence(read('test_output.log'))}\n\`\`\`\n</details>`
-              );
+              sections.push({
+                heading: '⚠️ **Tests failed!**',
+                summary: 'Test Output',
+                text: read('test_output.log'),
+              });
             }
 
             if (buildFailed) {
-              sections.push(
-                `❌ **Build failed!**\n\n<details><summary>Build Output</summary>\n\n\`\`\`\n` +
-                `${fence(read('build_output.log'))}\n\`\`\`\n</details>`
-              );
+              sections.push({
+                heading: '❌ **Build failed!**',
+                summary: 'Build Output',
+                text: read('build_output.log'),
+              });
             } else {
               const metrics = read('build_output.log')
                 .split('\n')
                 .filter((line) => line.includes('dist/assets/'))
                 .join('\n');
-              sections.push(
-                `✅ **Build successful!**\n\n<details><summary>Build Size Metrics</summary>\n\n\`\`\`\n` +
-                `${fence(metrics || 'Metrics not found')}\n\`\`\`\n</details>`
-              );
+              sections.push({
+                heading: '✅ **Build successful!**',
+                summary: 'Build Size Metrics',
+                text: metrics || 'Metrics not found',
+              });
             }
+
+            // GitHub rejects comment bodies over 65536 characters. Budget is shared
+            // across sections rather than applied per section, so tests and build
+            // both failing cannot add up past the cap.
+            const BODY_LIMIT = 60000;
+            const OVERHEAD = 600;
+            const perSection = Math.floor((BODY_LIMIT - OVERHEAD) / sections.length);
 
             // One comment per PR, edited in place, so a PR with many pushes does
             // not accumulate a wall of near-identical reports.
             const MARKER = '<!-- chainvoice-pr-report -->';
-            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.payload.workflow_run.id}`;
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${run.id}`;
             const body = [
               MARKER,
-              sections.join('\n\n'),
-              `<sub>[Workflow run](${runUrl}) · commit ${context.payload.workflow_run.head_sha.slice(0, 7)}</sub>`,
+              ...sections.map(
+                (s) =>
+                  `${s.heading}\n\n<details><summary>${s.summary}</summary>\n\n\`\`\`\n` +
+                  `${fence(s.text, perSection)}\n\`\`\`\n</details>`,
+              ),
+              `<sub>[Workflow run](${runUrl}) · commit ${run.head_sha.slice(0, 7)}</sub>`,
             ].join('\n\n');
 
             const comments = await github.paginate(github.rest.issues.listComments, {
               owner, repo, issue_number: prNumber, per_page: 100,
             });
-            const existing = comments.find((c) => c.body?.includes(MARKER));
+            // Must be our own comment: matching the marker anywhere in any comment
+            // would let a PR author plant it and have their comment overwritten.
+            const existing = comments.find(
+              (c) => c.user?.login === 'github-actions[bot]' && c.body?.startsWith(MARKER),
+            );
 
             if (existing) {
               await github.rest.issues.updateComment({

--- a/.github/workflows/pr-report.yml
+++ b/.github/workflows/pr-report.yml
@@ -1,0 +1,145 @@
+name: PR Report
+
+# Companion to test.yml. A `pull_request` run from a fork gets a read-only
+# GITHUB_TOKEN no matter what its `permissions:` block asks for, so labelling and
+# commenting from inside that run always fails with
+# "Resource not accessible by integration". `workflow_run` runs in the base-repo
+# context with a real write token, so the reporting lives here instead.
+on:
+  workflow_run:
+    workflows: ['Test and Build']
+    types: [completed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  report:
+    if: github.event.workflow_run.event == 'pull_request'
+    runs-on: ubuntu-latest
+    steps:
+      # This job holds a write token, so it must never check out or execute the
+      # PR's code. It only reads text out of the artifact and quotes it.
+      - name: Download report data
+        id: download
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: pr-report
+          path: pr-report
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Label and comment
+        if: steps.download.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const { owner, repo } = context.repo;
+
+            const read = (name) => {
+              try {
+                return fs.readFileSync(`pr-report/${name}`, 'utf8');
+              } catch {
+                return '';
+              }
+            };
+
+            const prNumber = Number(read('pr_number').trim());
+            if (!prNumber) {
+              core.info('No PR number in artifact; nothing to report.');
+              return;
+            }
+
+            const testsFailed = read('tests_failed').trim() === 'true';
+            const buildFailed = read('build_failed').trim() === 'true';
+
+            // Artifact contents come from a fork's build. Fence-breaking is the
+            // only thing quoting it can do, but neuter it anyway.
+            const fence = (text, limit = 60000) => {
+              let out = text.replace(/`/g, 'ˋ');
+              if (out.length > limit) out = out.slice(-limit);
+              return out.trim() || '(no output)';
+            };
+
+            const LABELS = {
+              'test case failing': { color: 'd93f0b', description: 'Automated tests are failing on this PR' },
+              'build failed': { color: 'b60205', description: 'The production build is failing on this PR' },
+            };
+
+            const setLabel = async (name, shouldHave) => {
+              if (shouldHave) {
+                try {
+                  await github.rest.issues.getLabel({ owner, repo, name });
+                } catch {
+                  await github.rest.issues.createLabel({ owner, repo, name, ...LABELS[name] });
+                }
+                await github.rest.issues.addLabels({
+                  owner, repo, issue_number: prNumber, labels: [name],
+                });
+              } else {
+                try {
+                  await github.rest.issues.removeLabel({
+                    owner, repo, issue_number: prNumber, name,
+                  });
+                } catch {
+                  // Label was not applied; nothing to remove.
+                }
+              }
+            };
+
+            await setLabel('test case failing', testsFailed);
+            await setLabel('build failed', buildFailed);
+
+            const sections = [];
+
+            if (testsFailed) {
+              sections.push(
+                `⚠️ **Tests failed!**\n\n<details><summary>Test Output</summary>\n\n\`\`\`\n` +
+                `${fence(read('test_output.log'))}\n\`\`\`\n</details>`
+              );
+            }
+
+            if (buildFailed) {
+              sections.push(
+                `❌ **Build failed!**\n\n<details><summary>Build Output</summary>\n\n\`\`\`\n` +
+                `${fence(read('build_output.log'))}\n\`\`\`\n</details>`
+              );
+            } else {
+              const metrics = read('build_output.log')
+                .split('\n')
+                .filter((line) => line.includes('dist/assets/'))
+                .join('\n');
+              sections.push(
+                `✅ **Build successful!**\n\n<details><summary>Build Size Metrics</summary>\n\n\`\`\`\n` +
+                `${fence(metrics || 'Metrics not found')}\n\`\`\`\n</details>`
+              );
+            }
+
+            // One comment per PR, edited in place, so a PR with many pushes does
+            // not accumulate a wall of near-identical reports.
+            const MARKER = '<!-- chainvoice-pr-report -->';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.payload.workflow_run.id}`;
+            const body = [
+              MARKER,
+              sections.join('\n\n'),
+              `<sub>[Workflow run](${runUrl}) · commit ${context.payload.workflow_run.head_sha.slice(0, 7)}</sub>`,
+            ].join('\n\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner, repo, issue_number: prNumber, per_page: 100,
+            });
+            const existing = comments.find((c) => c.body?.includes(MARKER));
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner, repo, comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner, repo, issue_number: prNumber, body,
+              });
+            }

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 20
           cache: 'npm'
@@ -56,14 +56,13 @@ jobs:
           npm run build > build_output.log 2>&1 || echo "BUILD_FAILED=true" >> $GITHUB_ENV
           cat build_output.log
 
-      # github.event.workflow_run.pull_requests is empty for forked PRs, so the
-      # reporting workflow cannot recover the PR number from the event payload.
-      # Hand it over through the artifact instead.
+      # Results only. This job runs the fork's own copy of this file, so nothing
+      # written here is trustworthy; pr-report.yml resolves the target PR from the
+      # workflow_run payload rather than from anything in this artifact.
       - name: Collect report data
         if: always() && github.event_name == 'pull_request'
         run: |
           mkdir -p pr-report
-          echo "${{ github.event.pull_request.number }}" > pr-report/pr_number
           echo "${TESTS_FAILED:-false}" > pr-report/tests_failed
           echo "${BUILD_FAILED:-false}" > pr-report/build_failed
           cp test_output.log pr-report/ 2>/dev/null || true
@@ -71,7 +70,7 @@ jobs:
 
       - name: Upload report data
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: pr-report
           path: frontend/pr-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,19 +10,20 @@ on:
     paths:
       - 'frontend/**'
 
+# Read-only on purpose. This workflow runs untrusted fork code, so it must not
+# hold a token that can write to the repo. Labels and the build-size comment are
+# posted by pr-report.yml, which runs after this one in the base-repo context.
 permissions:
-  issues: write
-  pull-requests: write
   contents: read
 
 jobs:
   test-and-build:
     runs-on: ubuntu-latest
-    
+
     defaults:
       run:
         working-directory: ./frontend
-        
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -48,56 +49,6 @@ jobs:
           npm run test:ci > test_output.log 2>&1 || echo "TESTS_FAILED=true" >> $GITHUB_ENV
           cat test_output.log
 
-      - name: Handle Test Failure
-        if: env.TESTS_FAILED == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            let testOutput = '';
-            try {
-              testOutput = fs.readFileSync('./frontend/test_output.log', 'utf8');
-              if (testOutput.length > 60000) {
-                testOutput = testOutput.substring(testOutput.length - 60000);
-              }
-            } catch (e) {
-              testOutput = 'Could not read test output.';
-            }
-            
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['test case failing']
-            });
-            
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `⚠️ **Tests failed!**\n\n<details><summary>Test Output</summary>\n\n\`\`\`\n${testOutput}\n\`\`\`\n</details>`
-            });
-            
-      - name: Fail if tests failed
-        if: env.TESTS_FAILED == 'true'
-        run: exit 1
-
-      - name: Remove test failure label (if passed)
-        if: env.TESTS_FAILED != 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.issue.number,
-                name: 'test case failing'
-              });
-            } catch (e) {
-              // Ignore if label doesn't exist
-            }
-
       - name: Run build
         id: build
         continue-on-error: true
@@ -105,40 +56,30 @@ jobs:
           npm run build > build_output.log 2>&1 || echo "BUILD_FAILED=true" >> $GITHUB_ENV
           cat build_output.log
 
-      - name: Handle Build Failure
-        if: env.BUILD_FAILED == 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
-        with:
-          script: |
-            await github.rest.issues.addLabels({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              labels: ['build failed']
-            });
+      # github.event.workflow_run.pull_requests is empty for forked PRs, so the
+      # reporting workflow cannot recover the PR number from the event payload.
+      # Hand it over through the artifact instead.
+      - name: Collect report data
+        if: always() && github.event_name == 'pull_request'
+        run: |
+          mkdir -p pr-report
+          echo "${{ github.event.pull_request.number }}" > pr-report/pr_number
+          echo "${TESTS_FAILED:-false}" > pr-report/tests_failed
+          echo "${BUILD_FAILED:-false}" > pr-report/build_failed
+          cp test_output.log pr-report/ 2>/dev/null || true
+          cp build_output.log pr-report/ 2>/dev/null || true
 
-      - name: Report Build Size
-        if: env.BUILD_FAILED != 'true' && github.event_name == 'pull_request'
-        uses: actions/github-script@v7
+      - name: Upload report data
+        if: always() && github.event_name == 'pull_request'
+        uses: actions/upload-artifact@v4
         with:
-          script: |
-            const fs = require('fs');
-            let buildOutput = '';
-            try {
-              buildOutput = fs.readFileSync('./frontend/build_output.log', 'utf8');
-              const lines = buildOutput.split('\n');
-              const metrics = lines.filter(line => line.includes('dist/assets/')).join('\n');
-              buildOutput = metrics || 'Metrics not found';
-            } catch (e) {
-              buildOutput = 'Could not read build output.';
-            }
-            
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `✅ **Build successful!**\n\n<details><summary>Build Size Metrics</summary>\n\n\`\`\`\n${buildOutput}\n\`\`\`\n</details>`
-            });
+          name: pr-report
+          path: frontend/pr-report
+          retention-days: 1
+
+      - name: Fail if tests failed
+        if: env.TESTS_FAILED == 'true'
+        run: exit 1
 
       - name: Fail if build failed
         if: env.BUILD_FAILED == 'true'


### PR DESCRIPTION
###  Addressed Issues:

No filed issue — reporting this from the failing runs themselves. The `Test and Build` check has been red on **every** open PR.

###  Screenshots/Recordings:

Not applicable — CI configuration only, no interface change.

Evidence instead. Step conclusions for [run 32115803453](https://github.com/StabilityNexus/Chainvoice/actions/runs/32115803453/job/95647166998) (PR #196):

| Step | Result |
| --- | --- |
| Run lint | ✅ |
| Run tests with coverage | ✅ |
| Run build | ✅ |
| **Report Build Size** | ❌ |

```
RequestError [HttpError]: Resource not accessible by integration
  status: 403,
  method: 'POST',
  url: 'https://api.github.com/repos/StabilityNexus/Chainvoice/issues/196/comments'
##[error]Unhandled error: HttpError: Resource not accessible by integration
```

Same step, same error, on every recent PR run:

| Run | Branch | Failing step |
| --- | --- | --- |
| 32116044336 | `feat/require-key-registration` | Report Build Size |
| 32115803453 | `refactor/rename-key-registry` | Report Build Size |
| 31811809636 | `feat/require-key-registration` | Report Build Size |
| 31582547148 | `docs/add-maintainers-and-logo` | Report Build Size |

###  Additional Notes:

**Cause.** A `pull_request` run triggered from a fork gets a read-only `GITHUB_TOKEN` regardless of what the workflow's `permissions:` block requests — that is the point of the fork restriction, and it cannot be granted around. `test.yml` asked for `issues: write` and `pull-requests: write` and then called `addLabels` and `createComment`, so those calls were always going to be refused. Contributors work from forks, so this affects all PRs.

The neighbouring `Remove test failure label` step makes the same forbidden call. It only looks healthy because it swallows the error in a `try/catch`, so the failure surfaced solely on `Report Build Size`, which does not.

`Handle Test Failure` and `Handle Build Failure` carry the same latent bug: on a fork PR with genuinely broken tests they would 403 and replace the real reason with a permissions error.

**Fix.** Split the build from the reporting, since only the reporting needs write access.

`test.yml` drops to `contents: read` and makes zero API calls. It runs lint / test / build, writes the PR number, the two pass-fail flags, and both logs into a `pr-report` artifact under `if: always()`, then fails the job if tests or the build failed. The check now goes red for real reasons only.

`pr-report.yml` (new) triggers on `workflow_run: [completed]` for `Test and Build`. That event runs in the **base-repo** context with a genuine write token, so it can label and comment. Behaviour is preserved: `test case failing` and `build failed` are added when the matching step failed and removed when it did not, and the build-size comment uses the same `dist/assets/` filter as before, plus the test log on failure and the build log when the build itself breaks.

Details worth a reviewer's attention:

- **The target PR is resolved from the `workflow_run` payload, never from the artifact.** `pull_requests[0]` covers same-repo PRs; for forks that array is empty, so it falls back to a `pulls.list` lookup keyed on the run's own `head_repository` and `head_branch`, preferring an exact `head_sha` match. Taking the number from the artifact — as the first push of this branch did — was a privilege escalation, since a fork controls its own copy of `test.yml` and could have pointed the privileged job at any issue in the repo.
- The surviving artifact fields (`tests_failed`, `build_failed`, the two logs) are advisory. A fork can claim its tests passed, but only on its own PR, and the required check's conclusion is what actually gates merge.
- **The reporting job never checks out the PR's code.** It holds a write token, so executing fork code there would be a privilege-escalation path. It only reads text out of the artifact and quotes it, with backticks replaced so a crafted log cannot break out of the code fence and inject markdown.
- Neither label exists in this repo today (we have `bug`, `documentation`, `duplicate`, `enhancement`, `good first issue`, `help wanted`, `invalid`, `question`, `wontfix`, `first-time-contributor`, `PR has merge conflicts`). The script creates the missing one on first use with a colour and description, rather than letting `addLabels` auto-generate an unstyled label.

**Two intentional behaviour changes**, flagged because they are visible:

1. The comment is **upserted** — one comment per PR, found via a hidden `<!-- chainvoice-pr-report -->` marker and edited in place on each push. The old version posted a fresh comment every run, which stacks up on a PR with several pushes. Say the word if you would rather keep an append-only history.
2. `Report Build Size` previously ran only on success and printed `Metrics not found` when the grep missed. Build failures now get the build log quoted instead, which is the more useful artifact when it is the build that broke.

#### ⚠️ Rollout caveat

**This PR cannot demonstrate its own fix, for two independent reasons.**

1. `workflow_run` workflows are read **only from the default branch**, so `pr-report.yml` stays dormant until this merges to `main`.
2. `test.yml` filters on `paths: frontend/**`, so a workflows-only change does not trigger it at all — `Test and Build` is absent from this PR's checks rather than green.

Both are expected. Labels and comments start working for every PR, fork or not, once this is on `main`.

Happy to add `.github/workflows/**` to that `paths` filter if you would like CI changes to be self-testing, but it means every workflow edit pays for a full frontend build, so I left it out of this PR.

**Not addressed here.** The runs also log `Node 20 is being deprecated. This workflow is running with Node 24 by default.` That concerns the runtime GitHub uses for the action wrappers, not the `setup-node` version used to build the app, and it was not causing any failure. Bumping `checkout` / `setup-node` / `github-script` to their current major versions belongs in its own PR.

**Review round.** CodeRabbit raised five findings on the first push and all five are fixed in `045f5668` — the artifact-controlled PR number above, missing `concurrency` (two quick pushes both created a report), an unbounded comment body (tests and build both failing produced ~120,000 characters against the API's 65,536 cap), marker matching that let a PR author's own comment be overwritten, and unpinned action tags. Every action in both files is now pinned to a commit SHA; the other workflows still use tags, which is a separate cleanup.

One deviation: CodeRabbit also suggested reducing `pull-requests: write` to `read` after the lookup. I kept `write`. The escalation it was guarding against was the arbitrary-issue targeting, which the payload-derived lookup fixes; whether `issues: write` alone suffices for comments and labels on a *pull request* is exactly the kind of permission subtlety that caused this bug, and it cannot be tested before merge. Not worth re-creating a 403 to shed one scope — happy to tighten it in a follow-up once the happy path is confirmed on `main`.

**Verification.** Both files parse as YAML and the embedded `github-script` body passes `node --check`. The comment-budget arithmetic was checked against the worst case CodeRabbit constructed: tests and build both failing with 60,000-character logs now yields a 59,706-character body, and a 500,000-character log yields the same. The `workflow_run` half cannot be exercised before merge, per the caveat above.

### AI Usage Disclosure:

Check one of the checkboxes below:

- [ ] This PR does not contain AI-generated code at all.
- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I have used the following AI models and tools: **Claude Code (CLI), model Claude Opus 5**


## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] If applicable, I have made corresponding changes or additions to the documentation
- [x] If applicable, I have made corresponding changes or additions to tests
- [x] My changes generate no new warnings or errors
- [x] I have joined the [Discord server](https://discord.gg/hjUhu33uAn) and I will share a link to this PR with the project maintainers there
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] Once I submit my PR, CodeRabbit AI will automatically review it and I will address CodeRabbit's comments.
- [x] I have filled this PR template completely and carefully, and I understand that my PR may be closed without review otherwise.
