### PR TITLE
ci: stop hiding the preview base marker from its own artifact

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -85,8 +85,10 @@ jobs:
           npm run build -- --mode preview --base "$base"
 
           # Recorded so the publish job can refuse a build made for the wrong
-          # path, instead of publishing a page that loads nothing.
-          printf '%s' "$base" > dist/.preview-base
+          # path, instead of publishing a page that loads nothing. Not a
+          # dotfile: actions/upload-artifact leaves hidden files out of the
+          # artifact by default, and this has to survive the trip.
+          printf '%s' "$base" > dist/preview-base
 
           # A CNAME means something only at the site root, and the root belongs
           # to the production deploy.

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -178,13 +178,13 @@ jobs:
           # blank, which is worth an error rather than a puzzled contributor.
           # Stripped of anything but path characters before being echoed, since
           # the file came from the build.
-          built_base="$(tr -dc 'A-Za-z0-9/._-' < preview/.preview-base 2>/dev/null || true)"
+          built_base="$(tr -dc 'A-Za-z0-9/._-' < preview/preview-base 2>/dev/null || true)"
           if [ "$built_base" != "$EXPECTED_BASE" ]; then
             echo "::error::this build is for '${built_base:-<unset>}' but the site serves '${EXPECTED_BASE}'."
             echo "::error::set PREVIEW_PUBLIC_BASE=${{ needs.resolve.outputs.base_path }} in frontend/.env.preview"
             exit 1
           fi
-          rm -f preview/.preview-base
+          rm -f preview/preview-base
 
       - name: Publish to gh-pages
         env:


### PR DESCRIPTION
### Addressed Issues:

Follow-up to #211 — one line that PR needed and did not have when it merged. Previews cannot publish without it.

### Description of Changes:

`actions/upload-artifact` leaves hidden files out of the artifact unless `include-hidden-files` says otherwise, so `dist/.preview-base` never reached the publish job. Proof from #211's own build, artifact `9947008574`:

```
entries: 231
entries with a dot-prefixed component: NONE
```

The publish job reads that file to check the build was made for the path this site actually serves. With the file gone it reads nothing, reports `built '<unset>'`, and refuses to publish — so on current `main` every preview fails the guard.

Renamed to `dist/preview-base` rather than switching on `include-hidden-files`, so it does not depend on that input existing at the pinned action version. The publish job still deletes it before committing, so it is never served.

### Verification

Guard exercised locally against a scratch bare repo in all three states:

- built for `/Chainvoice/...` against a `/` site → rejected, naming the value to set
- built for `/pr-preview/pr-209/` against a `/` site → passes, marker consumed before publishing
- marker absent → rejected as `<unset>`, which is what `main` does today

### AI Usage Disclosure:

- [x] This PR contains AI-generated code. I have read the [AI Usage Policy](https://github.com/AOSSIE-Org/Info/blob/main/AI-UsagePolicy.md) and this PR complies with this policy. I have tested the code locally and I am responsible for it.

I used Claude Code to find this by inspecting the artifact zip produced by #211's build, and to verify the fix.

## Checklist
- [x] My PR addresses a single issue, fixes a single bug or makes a single improvement.
- [x] My code follows the project's code style and conventions
- [x] My changes generate no new warnings or errors
- [x] I have read the [Contribution Guidelines](../CONTRIBUTING.md)
